### PR TITLE
Bump reflow maven plugin to 2.3.0

### DIFF
--- a/openmeetings-server/src/site/resources/css/site.css
+++ b/openmeetings-server/src/site/resources/css/site.css
@@ -1,15 +1,31 @@
 /* Licensed under the Apache License, Version 2.0 (the "License") http://www.apache.org/licenses/LICENSE-2.0 */
+body {
+	/* prevent jump page on load (before calculation top navbar) */
+	padding-top: 56px;
+}
+
 iframe {
 	width: 100%;
 	min-height: 700px;
+}
+
+.apachecon-banner {
+  float: left;
+  margin: 5px;
 }
 .apachecon-banner.bannerRight img {
 	max-width: 250px;
 	height: initial !important;
 }
+
 .bannerRight img, .bannerLeft img {
 	height: 80px !important;
 }
+
+.header {
+  padding-top: 3rem;
+}
+
 .color-highlight {
 	color: #cb2533;
 	text-transform: uppercase;

--- a/openmeetings-server/src/site/resources/js/site.js
+++ b/openmeetings-server/src/site/resources/js/site.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
 		$('ul.nav li a[title="' + topics[i] + '"').append('&nbsp;&nbsp;<span class="badge badge-success">New</span>')
 	}
 	// "ACNA" banner on the right
-	$('.d-lg-block').append(
+	$('.header').append(
 		$('<div>')
 			.append($('<a href="https://www.apache.org/events/current-event" class="apachecon-banner bannerRight">')
 				.append($('<img src="https://www.apache.org/events/current-event-234x60.png">'))

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<!-- plugin versions -->
 		<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+		<maven-site-plugin.version>3.8.2</maven-site-plugin.version>
 		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 		<minify-maven-plugin.version>1.7.6</minify-maven-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
@@ -50,7 +50,7 @@
 		<checksum-maven-plugin.version>1.8</checksum-maven-plugin.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<license-maven-plugin.version>1.16</license-maven-plugin.version>
-		<reflow-maven-skin.version>2.2.0</reflow-maven-skin.version>
+		<reflow-maven-skin.version>2.3.0</reflow-maven-skin.version>
 		<reflow-theme>cerulean</reflow-theme>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -69,7 +69,7 @@
 				<column>Development</column>
 			</bottomNav>
 			<toc position="fixed">sidebar</toc>
-			<navbar cssClass="navbar-dark bg-primary"/>
+			<navbar theme="dark" background="primary"/>
 			<skinAttribution>false</skinAttribution>
 			<highlightJs>true</highlightJs>
 			<highlightJsTheme>github</highlightJsTheme>


### PR DESCRIPTION
Hi @solomax,

I publish a new version of reflow maven plugin and I would like to suggest you this pull request in order to simplify your work.
This version modifies how the header is displayed (See the home page of site https://devacfr.github.io/reflow-maven-skin/) and the `cssClass` attribute of each component do not override anymore `theme` and `background` attribute.