### PR TITLE
OPENMEETINGS-2225 fix for when in Mobile view the drop down menu is h…

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-general.css
+++ b/openmeetings-web/src/main/webapp/css/raw-general.css
@@ -183,6 +183,7 @@ html, body {
 	min-width: 150px;
 }
 #contents {
+	padding-top: var(--menu-height);
 	height: calc(100% - var(--menu-height));
 }
 #feedcontainer {

--- a/openmeetings-web/src/main/webapp/css/raw-menu.css
+++ b/openmeetings-web/src/main/webapp/css/raw-menu.css
@@ -6,7 +6,12 @@
     z-index: 2010;
     width: 100%;
 }
+
 .room-block .menu {
+	top: 0px;
+	position: absolute;
+    z-index: 1010;
+    width: 100%;
 	height: var(--room-menu-height);
 }
 .room-block .menu .top.exit {

--- a/openmeetings-web/src/main/webapp/css/raw-menu.css
+++ b/openmeetings-web/src/main/webapp/css/raw-menu.css
@@ -10,7 +10,7 @@
 .room-block .menu {
 	top: 0px;
 	position: absolute;
-    z-index: 1010;
+    z-index: 2010;
     width: 100%;
 	height: var(--room-menu-height);
 }

--- a/openmeetings-web/src/main/webapp/css/raw-menu.css
+++ b/openmeetings-web/src/main/webapp/css/raw-menu.css
@@ -2,6 +2,9 @@
 #menu .navbar {
 	padding-top: 0;
 	padding-bottom: 0;
+	position: absolute;
+    z-index: 1000;
+    width: 100%;
 }
 .room-block .menu {
 	height: var(--room-menu-height);

--- a/openmeetings-web/src/main/webapp/css/raw-menu.css
+++ b/openmeetings-web/src/main/webapp/css/raw-menu.css
@@ -3,7 +3,7 @@
 	padding-top: 0;
 	padding-bottom: 0;
 	position: absolute;
-    z-index: 1000;
+    z-index: 2010;
     width: 100%;
 }
 .room-block .menu {

--- a/openmeetings-web/src/main/webapp/css/raw-variables.css
+++ b/openmeetings-web/src/main/webapp/css/raw-variables.css
@@ -42,6 +42,7 @@ body.no-menu {
 }
 .main.room {
 	--header-height: 0px;
+	--room-menu-height: 34px;
 	--room-sidebar-width: 315px;
 	--room-wb-tabs-height: 45px;
 	--room-sidebar-header-height: 37px;

--- a/openmeetings-web/src/main/webapp/css/raw-variables.css
+++ b/openmeetings-web/src/main/webapp/css/raw-variables.css
@@ -42,7 +42,7 @@ body.no-menu {
 }
 .main.room {
 	--header-height: 0px;
-	--room-menu-height: 34px;
+	--room-menu-height: 38px;
 	--room-sidebar-width: 315px;
 	--room-wb-tabs-height: 45px;
 	--room-sidebar-header-height: 37px;

--- a/openmeetings-web/src/main/webapp/css/raw-variables.css
+++ b/openmeetings-web/src/main/webapp/css/raw-variables.css
@@ -42,7 +42,6 @@ body.no-menu {
 }
 .main.room {
 	--header-height: 0px;
-	--room-menu-height: 34px;
 	--room-sidebar-width: 315px;
 	--room-wb-tabs-height: 45px;
 	--room-sidebar-header-height: 37px;


### PR DESCRIPTION
OPENMEETINGS-2225 When in Mobiel view, inside the room, the navigation bar gets hidden behind the UI for the conference room.

Removing the css attribute had the effect that it moves down again.

I could not find any regression issue or bad side-effect of deleting this attribute elsewhere. But obviously I might be wrong after this long time!

see result:
![image](https://user-images.githubusercontent.com/5152064/78465401-3ee90d00-7749-11ea-8724-8a1a586f628d.png)
