### PR TITLE
OPENMEETINGS-2251 Fix JS and CSS for tabbar for right click menu

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -93,7 +93,7 @@
 			<div class="col">
 				<div class="doc-group input-group input-group-sm" aria-label="...">
 					<div class="input-group-prepend">
-						<button type="button" class="btn btn-outline-secondary btn-no-border up" wicket:message="title:256">
+						<button type="button" class="btn btn-outline-secondary up" wicket:message="title:256">
 							<i class="fas fa-reply"></i>
 						</button>
 					</div>
@@ -105,7 +105,7 @@
 						<div class="last-page input-group-text">1</div>
 					</div>
 					<div class="input-group-append">
-						<button type="button" class="btn btn-outline-secondary btn-no-border down" wicket:message="title:257">
+						<button type="button" class="btn btn-outline-secondary down" wicket:message="title:257">
 							<i class="fas fa-share"></i>
 						</button>
 					</div>
@@ -113,7 +113,7 @@
 			</div>
 			<div class="col input-group input-group-sm" aria-label="...">
 				<div class="input-group-prepend">
-					<button type="button" class="btn btn-outline-secondary btn-no-border zoom-out" wicket:message="title:259">
+					<button type="button" class="btn btn-outline-secondary zoom-out" wicket:message="title:259">
 						<i class="fas fa-search-minus"></i>
 					</button>
 				</div>
@@ -131,13 +131,13 @@
 					<option value="4.00">400%</option>
 				</select>
 				<div class="input-group-append">
-					<button type="button" class="btn btn-outline-secondary btn-no-border zoom-in" wicket:message="title:260">
+					<button type="button" class="btn btn-outline-secondary zoom-in" wicket:message="title:260">
 						<i class="fas fa-search-plus"></i>
 					</button>
 				</div>
 			</div>
 			<div class="col settings-group">
-				<button type="button" class="btn btn-outline-secondary btn-sm btn-no-border settings" wicket:message="title:lbl.settings.whiteboard">
+				<button type="button" class="btn btn-outline-secondary btn-sm settings" wicket:message="title:lbl.settings.whiteboard">
 					<i class="fas fa-cog"></i>
 				</button>
 			</div>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -46,7 +46,7 @@
 				</a>
 			</li>
 		</ul>
-		<button id="wb-tab-close" class="btn btn-sm wb-tab-close"
+		<button id="wb-tab-close" class="btn btn-sm btn-outline-secondary btn-no-border wb-tab-close"
 				wicket:message="title:85,data-btn-ok-label:54,data-btn-cancel-label:lbl.cancel,data-title:832,data-content:1313"
 				data-btn-ok-class="btn btn-sm btn-danger"
 				data-btn-ok-icon-class="fas fa-exclamation-triangle"
@@ -93,7 +93,7 @@
 			<div class="col">
 				<div class="doc-group input-group input-group-sm" aria-label="...">
 					<div class="input-group-prepend">
-						<button type="button" class="btn btn-outline-secondary up" wicket:message="title:256">
+						<button type="button" class="btn btn-outline-secondary btn-no-border up" wicket:message="title:256">
 							<i class="fas fa-reply"></i>
 						</button>
 					</div>
@@ -105,7 +105,7 @@
 						<div class="last-page input-group-text">1</div>
 					</div>
 					<div class="input-group-append">
-						<button type="button" class="btn btn-outline-secondary down" wicket:message="title:257">
+						<button type="button" class="btn btn-outline-secondary btn-no-border down" wicket:message="title:257">
 							<i class="fas fa-share"></i>
 						</button>
 					</div>
@@ -113,7 +113,7 @@
 			</div>
 			<div class="col input-group input-group-sm" aria-label="...">
 				<div class="input-group-prepend">
-					<button type="button" class="btn btn-outline-secondary zoom-out" wicket:message="title:259">
+					<button type="button" class="btn btn-outline-secondary btn-no-border zoom-out" wicket:message="title:259">
 						<i class="fas fa-search-minus"></i>
 					</button>
 				</div>
@@ -131,13 +131,13 @@
 					<option value="4.00">400%</option>
 				</select>
 				<div class="input-group-append">
-					<button type="button" class="btn btn-outline-secondary zoom-in" wicket:message="title:260">
+					<button type="button" class="btn btn-outline-secondary btn-no-border zoom-in" wicket:message="title:260">
 						<i class="fas fa-search-plus"></i>
 					</button>
 				</div>
 			</div>
 			<div class="col settings-group">
-				<button type="button" class="btn btn-outline-secondary btn-sm settings" wicket:message="title:lbl.settings.whiteboard">
+				<button type="button" class="btn btn-outline-secondary btn-sm btn-no-border settings" wicket:message="title:lbl.settings.whiteboard">
 					<i class="fas fa-cog"></i>
 				</button>
 			</div>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -39,10 +39,14 @@
 		<div id="wb-tabbar-ctrls-right">
 			<div class="next clickable om-icon big"></div>
 		</div>
-		<ul><li id="wb-area-tab" class="nav-item">
-			<a class="nav-link" data-toggle="tab" role="tab"><span></span></a>
-		</li></ul>
-		<button id="wb-tab-close" class="btn btn-sm btn-outline-secondary"
+		<ul>
+			<li id="wb-area-tab" class="nav-item">
+				<a class="nav-link" data-toggle="tab" role="tab">
+					<span class="wb-nav-tab-text"></span>
+				</a>
+			</li>
+		</ul>
+		<button id="wb-tab-close" class="btn btn-sm wb-tab-close"
 				wicket:message="title:85,data-btn-ok-label:54,data-btn-cancel-label:lbl.cancel,data-title:832,data-content:1313"
 				data-btn-ok-class="btn btn-sm btn-danger"
 				data-btn-ok-icon-class="fas fa-exclamation-triangle"

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
@@ -131,6 +131,14 @@ var DrawWbArea = function() {
 		}
 		const link = li.find('a')
 			, wbId = link.data('wb-id');
+		// Apply right click menu only to the text item
+		li.find(".nav-link").find("span").first().contextmenu(
+			function(e) {
+				e.preventDefault();
+				$('#wb-rename-menu').show().data('wb-id', wbId)
+					.position({my: 'left top', collision: 'none', of: _getWbTab(wbId)});
+			});
+		
 		link.append(OmUtil.tmpl('#wb-tab-close'));
 		li.find('button')
 			.confirmation({
@@ -248,7 +256,8 @@ var DrawWbArea = function() {
 			callback();
 		}
 		$('#wb-rename-menu').menu().find('.wb-rename').click(function() {
-			_getWbTab($(this).parent().data('wb-id')).find('a span').trigger('dblclick');
+			const textSpan = _getWbTab($(this).parent().data('wb-id')).find('.wb-nav-tab-text').first();
+			textSpan.trigger('dblclick');
 		});
 	}
 
@@ -268,14 +277,6 @@ var DrawWbArea = function() {
 			, tcid = __getWbContentId(obj.wbId)
 			, wb = OmUtil.tmpl('#wb-area', tcid).attr('aria-labelledby', tid)
 			, li = OmUtil.tmpl('#wb-area-tab')
-				.contextmenu(function(e) {
-					if (role !== PRESENTER) {
-						return;
-					}
-					e.preventDefault();
-					$('#wb-rename-menu').show().data('wb-id', obj.wbId)
-						.position({my: 'left top', collision: 'none', of: _getWbTab(obj.wbId)});
-				})
 			, link = li.find('a');
 		link.attr('id', tid).attr('data-wb-id', obj.wbId).attr('href', '#' + tcid).attr('aria-controls', tcid);
 		_setTabName(link, obj.name)

--- a/openmeetings-web/src/main/webapp/css/raw-wb.css
+++ b/openmeetings-web/src/main/webapp/css/raw-wb.css
@@ -46,13 +46,15 @@ html[dir="rtl"] .room-block .sb-wb .wb-block {
 	padding-right: 25px;
 }
 .wb-tab-close {
-	color: var(--secondary);
 	width: 20px;
 	height: 20px;
 	padding: 0;
 	position: absolute;
 	top: 2px;
 	right: 2px;
+}
+.btn-no-border {
+	border: none;
 }
 .room-block .sb-wb .wb-block .tabs .wb-tab-content {
 	height: calc(100% - var(--room-wb-tabs-height));

--- a/openmeetings-web/src/main/webapp/css/raw-wb.css
+++ b/openmeetings-web/src/main/webapp/css/raw-wb.css
@@ -45,7 +45,8 @@ html[dir="rtl"] .room-block .sb-wb .wb-block {
 	position: relative;
 	padding-right: 25px;
 }
-.room-block .sb-wb .wb-block .tabs .wb-tabbar li a button {
+.wb-tab-close {
+	color: var(--secondary);
 	width: 20px;
 	height: 20px;
 	padding: 0;


### PR DESCRIPTION
Fixes:
* right click menu only over whiteboard name span/text. Instead of entire tab element. Including the close icon
* Update close icon to remove border 
* Fix that right click action is pointing to correct trigger

New layout looks a bit more light:
![image](https://user-images.githubusercontent.com/5152064/79057692-2c765280-7cb8-11ea-9838-eeb10fbe9d00.png)

Tested fix with 2 participants across Chrome + Firefox.