### PR TITLE
OPENMEETINGS-2256 Fix PDF with cropbox different from mediabox to con…

### DIFF
--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/converter/ImageConverter.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/converter/ImageConverter.java
@@ -181,6 +181,7 @@ public class ImageConverter extends BaseConverter {
 		String[] argv = new String[] {
 			getPathToConvert()
 			, "-density", getDpi()
+			, "-define", "pdf:use-cropbox=true"
 			, pdf.getCanonicalPath()
 			, "+profile", "'*'"
 			, "-quality", getQuality()


### PR DESCRIPTION
This is based on the comment from: 
https://github.com/ImageMagick/ImageMagick/discussions/1891

There is some explanation on why cropbox might be different then mediabox here:
https://imagemagick.org/script/formats.php#supported
=> PDF
> Some PDF files, however, have a CropBox or TrimBox that is smaller than the MediaBox and may include white space, registration or cutting marks outside the CropBox or TrimBox. To force ImageMagick to use the CropBox or TrimBox rather than the MediaBox, use -define (e.g. -define pdf:use-cropbox=true or -define pdf:use-trimbox=true).

I was regression testing some other PDFs and DOC/XLS and there wasn't any side effect.

I think by default cropbox is same as mediabox.