### PR TITLE
OPENMEETINGS-2247 Fix css that is now loaded from bootstrap

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-wb.css
+++ b/openmeetings-web/src/main/webapp/css/raw-wb.css
@@ -48,13 +48,13 @@ html[dir="rtl"] .room-block .sb-wb .wb-block {
 .wb-tab-close {
 	width: 20px;
 	height: 20px;
-	padding: 0;
 	position: absolute;
-	top: 2px;
+	top: 0px;
 	right: 2px;
 }
-.btn-no-border {
+.btn-outline-secondary.btn-no-border {
 	border: none;
+	padding: 0;
 }
 .room-block .sb-wb .wb-block .tabs .wb-tab-content {
 	height: calc(100% - var(--room-wb-tabs-height));


### PR DESCRIPTION
Fix up CSS. After CSP fix, bootstrap CSS gets loaded now. And that overwrites the border and padding.