### PR TITLE
OPENMEETINGS-2273 Room File Tree Details panel - Add header - Toggle download button enable rather then display and fix download of original for PDF and documents

### DIFF
--- a/openmeetings-db/src/main/java/org/apache/openmeetings/db/entity/file/BaseFileItem.java
+++ b/openmeetings-db/src/main/java/org/apache/openmeetings/db/entity/file/BaseFileItem.java
@@ -54,6 +54,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.openmeetings.db.bind.adapter.FileTypeAdapter;
 import org.apache.openmeetings.db.bind.adapter.IntAdapter;
 import org.apache.openmeetings.db.bind.adapter.LongAdapter;
@@ -296,7 +297,31 @@ public abstract class BaseFileItem extends HistoricalEntity {
 	public void setExternalType(String externalType) {
 		this.externalType = externalType;
 	}
+	
+	/**
+	 * Generates a link to download. As opposed to display it on the Whiteboard.
+	 * 
+	 * @param ext
+	 * @return
+	 */
+	public final File getDownloadFile(String ext) {
+		// passing in null for PRESENTATION won't return the original
+		if (ext == null && getType() != null && getType().equals(Type.PRESENTATION)) {
+			// could by either a Doc/XLS/PPT or just a PDF
+			return getFile(FilenameUtils.getExtension(getName()));
+		}
+		// for other file types passing in null should return original
+		return getFile(ext);
+	}
 
+	/**
+	 * Returns a file. But mostly to get a link for the Whiteboard.
+	 * 
+	 * In case of a Presentation it will try to assume the first slide if passing in null.
+	 * 
+	 * @param ext
+	 * @return
+	 */
 	public final File getFile(String ext) {
 		File f = null;
 		if (!isDeleted() && getHash() != null) {

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FileTreePanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FileTreePanel.html
@@ -52,11 +52,16 @@
 			<div wicket:id="tree"></div>
 		</div>
 		<div class="footer">
-			<span wicket:id="download" wicket:message="title:867"></span>
+			<span class="download" wicket:id="download" wicket:message="title:867"></span>
+			<div class="sizes">
+			    <span class="size font-weight-bold"><wicket:message key="923"/></span>
+				<span class="font-weight-bold">/</span>
+				<span class="font-weight-bold"><wicket:message key="924"/></span>
+			</div>
 			<div wicket:id="sizes" class="sizes">
 				<span class="size" wicket:message="title:923" wicket:id="homeSize"></span>
-				<span class="size">/</span>
-				<span class="size" wicket:message="title:924" wicket:id="publicSize"></span>
+				<span>/</span>
+				<span wicket:message="title:924" wicket:id="publicSize"></span>
 			</div>
 		</div>
 		<div wicket:id="errors"></div>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FileTreePanel.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FileTreePanel.java
@@ -158,8 +158,7 @@ public abstract class FileTreePanel extends Panel {
 
 		public void onDownlownClick(AjaxRequestTarget target, String ext) {
 			BaseFileItem fi = getLastSelected();
-			File f = ext == null && (Type.IMAGE == fi.getType() || Type.PRESENTATION == fi.getType())
-					? fi.getOriginal() : fi.getFile(ext);
+			File f = fi.getDownloadFile(ext);
 			if (f != null && f.exists()) {
 				dwnldFile = f;
 				downloader.initiate(target);
@@ -192,7 +191,7 @@ public abstract class FileTreePanel extends Panel {
 		final OmTreeProvider tp = new OmTreeProvider(roomId);
 		select(tp.getRoot(), null, false, false);
 		form.add(tree = new FileItemTree("tree", this, tp));
-		form.add(download.setVisible(false).setOutputMarkupPlaceholderTag(true));
+		form.add(download.setEnabled(false).setOutputMarkupPlaceholderTag(true));
 		add(form.add(downloader));
 	}
 
@@ -467,7 +466,7 @@ public abstract class FileTreePanel extends Panel {
 		}
 		updateSelected(target); //all finally selected are in the update list
 		if (target != null) {
-			target.add(trashBorder, download.setVisible(isDownloadable(lastSelected)));
+			target.add(trashBorder, download.setEnabled(isDownloadable(lastSelected)));
 		}
 	}
 

--- a/openmeetings-web/src/main/webapp/css/raw-tree.css
+++ b/openmeetings-web/src/main/webapp/css/raw-tree.css
@@ -17,6 +17,12 @@
 }
 .file-tree .footer {
 	height: var(--tree-footer-height);
+	display: flex;
+    flex-direction: column;
+}
+.file-tree .footer .download {
+	padding-left: 5px;
+	padding-right: 5px;
 }
 .file-tree .footer .sizes {
 	display: inline-block;

--- a/openmeetings-web/src/main/webapp/css/raw-tree.css
+++ b/openmeetings-web/src/main/webapp/css/raw-tree.css
@@ -18,7 +18,7 @@
 .file-tree .footer {
 	height: var(--tree-footer-height);
 	display: flex;
-    flex-direction: column;
+	flex-direction: column;
 }
 .file-tree .footer .download {
 	padding-left: 5px;

--- a/openmeetings-web/src/main/webapp/css/raw-variables.css
+++ b/openmeetings-web/src/main/webapp/css/raw-variables.css
@@ -38,7 +38,7 @@ body.no-menu {
 }
 .file-tree {
 	--tree-header-height: 36px;
-	--tree-footer-height: 80px;
+	--tree-footer-height: 70px;
 }
 .main.room {
 	--header-height: 0px;


### PR DESCRIPTION
Fixes OPENMEETINGS-2273
 - Adding heading to the size of public and personal drive. There is enough space for it.
 - Adjust height to 70px
 - Toggle download button enable disable instead of visible true/false
 - Fix so that you can actually download original. getFile(null) defaults to first slide and gives you a PNG. Not the original

New default view of the panel without selecting anything:
![image](https://user-images.githubusercontent.com/5152064/79621031-08a68700-8166-11ea-8623-90575a5f582f.png)

When selecting a file it enables the download button:
![image](https://user-images.githubusercontent.com/5152064/79621096-41def700-8166-11ea-8cee-f90ef7f69cef.png)

This won't fix the dropdown next to the button:
* Drop down is still confusing, cause it shows file types and tries to enable the relevant ones. But when selecting one that is enabled mostly nothing happens
* It displays JPG in the download options but then gives you PNG
