### PR TITLE
OPENMEETINGS-2344 Resize according to size

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FolderPanel.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FolderPanel.java
@@ -24,6 +24,7 @@ import static org.apache.openmeetings.util.OpenmeetingsVariables.ATTR_TITLE;
 import java.util.Map.Entry;
 
 import org.apache.openmeetings.db.dao.file.FileItemDao;
+import org.apache.openmeetings.db.dao.file.FileItemLogDao;
 import org.apache.openmeetings.db.dao.record.RecordingDao;
 import org.apache.openmeetings.db.entity.file.BaseFileItem;
 import org.apache.openmeetings.db.entity.file.BaseFileItem.Type;
@@ -66,6 +67,8 @@ public class FolderPanel extends Panel implements IDraggableListener, IDroppable
 	private RecordingDao recDao;
 	@SpringBean
 	private FileItemDao fileDao;
+	@SpringBean
+	private FileItemLogDao fileLogDao;
 
 	public FolderPanel(String id, final IModel<BaseFileItem> model, final FileTreePanel treePanel) {
 		super(id, model);
@@ -225,6 +228,19 @@ public class FolderPanel extends Panel implements IDraggableListener, IDroppable
 		}
 		String cls = f instanceof Recording ? "recorditem " : "fileitem ";
 		style.append(f.isReadOnly() ? "readonlyitem " : cls);
+
+		long errorCount = fileLogDao.countErrors(f);
+		boolean hasError = errorCount != 0;
+		if (BaseFileItem.Type.RECORDING == f.getType()) {
+			Recording r = (Recording)f;
+			hasError |= (Status.RECORDING != r.getStatus() && Status.CONVERTING != r.getStatus() && !f.exists());
+		} else {
+			hasError |= !f.exists();
+		}
+		if (hasError) {
+			style.append("error");
+		}
+
 		return style;
 	}
 

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FolderPanel.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/tree/FolderPanel.java
@@ -24,7 +24,6 @@ import static org.apache.openmeetings.util.OpenmeetingsVariables.ATTR_TITLE;
 import java.util.Map.Entry;
 
 import org.apache.openmeetings.db.dao.file.FileItemDao;
-import org.apache.openmeetings.db.dao.file.FileItemLogDao;
 import org.apache.openmeetings.db.dao.record.RecordingDao;
 import org.apache.openmeetings.db.entity.file.BaseFileItem;
 import org.apache.openmeetings.db.entity.file.BaseFileItem.Type;
@@ -67,8 +66,6 @@ public class FolderPanel extends Panel implements IDraggableListener, IDroppable
 	private RecordingDao recDao;
 	@SpringBean
 	private FileItemDao fileDao;
-	@SpringBean
-	private FileItemLogDao fileLogDao;
 
 	public FolderPanel(String id, final IModel<BaseFileItem> model, final FileTreePanel treePanel) {
 		super(id, model);
@@ -228,19 +225,6 @@ public class FolderPanel extends Panel implements IDraggableListener, IDroppable
 		}
 		String cls = f instanceof Recording ? "recorditem " : "fileitem ";
 		style.append(f.isReadOnly() ? "readonlyitem " : cls);
-
-		long errorCount = fileLogDao.countErrors(f);
-		boolean hasError = errorCount != 0;
-		if (BaseFileItem.Type.RECORDING == f.getType()) {
-			Recording r = (Recording)f;
-			hasError |= (Status.RECORDING != r.getStatus() && Status.CONVERTING != r.getStatus() && !f.exists());
-		} else {
-			hasError |= !f.exists();
-		}
-		if (hasError) {
-			style.append("error");
-		}
-
 		return style;
 	}
 

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -397,19 +397,6 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 .room-block.narrow .sidebar .tab.om-icon.big .label {
 	display: none;
 }
-/*.room-block.narrow .sidebar .file-tree .file.item .name
-	, .room-block.narrow .sidebar .file-tree .file.item .name span
-{
-	width: calc(var(--room-sidebar-width) + var(--buffer-size));
-	width: 40px;
-}
-.room-block .sidebar .file-tree .file.item .name
-	, .room-block .sidebar .file-tree .file.item .name span
-{
-	max-width: calc(var(--room-sidebar-width) - 100px);
-	min-width: 60px;
-}
-*/
 .room-block .wait-moder {
 	position: fixed;
 	bottom: 30px;

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -397,11 +397,19 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 .room-block.narrow .sidebar .tab.om-icon.big .label {
 	display: none;
 }
-.room-block.narrow .sidebar .file-tree .file.item .name
+/*.room-block.narrow .sidebar .file-tree .file.item .name
 	, .room-block.narrow .sidebar .file-tree .file.item .name span
 {
+	width: calc(var(--room-sidebar-width) + var(--buffer-size));
 	width: 40px;
 }
+.room-block .sidebar .file-tree .file.item .name
+	, .room-block .sidebar .file-tree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 100px);
+	min-width: 60px;
+}
+*/
 .room-block .wait-moder {
 	position: fixed;
 	bottom: 30px;

--- a/openmeetings-web/src/main/webapp/css/raw-tree.css
+++ b/openmeetings-web/src/main/webapp/css/raw-tree.css
@@ -23,53 +23,89 @@
 .file-tree .footer .sizes .size {
 	padding-left: 5px;
 }
+/* Calc width with default for max level of 7 */
 .file-tree .file.item .name
 	, .file-tree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 58px);
+	max-width: calc(var(--room-sidebar-width) - 26px);
 	min-width: 60px;
 }
 .file-tree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 76px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 44px);
 }
 .file-tree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 94px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 62px);
 }
 .file-tree .tree-subtree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 112px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 80px);
 }
 .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 130px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 98px);
 }
 .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 148px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 116px);
 }
 .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 166px);
-	min-width: 60px;
+	max-width: calc(var(--room-sidebar-width) - 134px);
 }
 .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
 	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 184px);
+	max-width: calc(var(--room-sidebar-width) - 152px);
+}
+/* adding 32px extra space in case "broken" symbol is on same row*/
+.file-tree .broken .file.item .name
+	, .file-tree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 58px);
 	min-width: 60px;
+}
+.file-tree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 76px);
+}
+.file-tree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 94px);
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 112px);
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 130px);
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 148px);
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 166px);
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .broken .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 184px);
 }
 .trash-toolbar {
 	font-weight: bold;

--- a/openmeetings-web/src/main/webapp/css/raw-tree.css
+++ b/openmeetings-web/src/main/webapp/css/raw-tree.css
@@ -26,7 +26,49 @@
 .file-tree .file.item .name
 	, .file-tree .file.item .name span
 {
-	max-width: calc(var(--room-sidebar-width) - 100px);
+	max-width: calc(var(--room-sidebar-width) - 58px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 76px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 94px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 112px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 130px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 148px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 166px);
+	min-width: 60px;
+}
+.file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name
+	, .file-tree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .tree-subtree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 184px);
 	min-width: 60px;
 }
 .trash-toolbar {

--- a/openmeetings-web/src/main/webapp/css/raw-tree.css
+++ b/openmeetings-web/src/main/webapp/css/raw-tree.css
@@ -1,7 +1,6 @@
 /* Licensed under the Apache License, Version 2.0 (the "License") http://www.apache.org/licenses/LICENSE-2.0 */
 .file-tree {
 	vertical-align: top;
-	max-width: 350px;
 	height: 100%;
 	width: 100%;
 	display: inline-block;
@@ -23,6 +22,12 @@
 }
 .file-tree .footer .sizes .size {
 	padding-left: 5px;
+}
+.file-tree .file.item .name
+	, .file-tree .file.item .name span
+{
+	max-width: calc(var(--room-sidebar-width) - 100px);
+	min-width: 60px;
 }
 .trash-toolbar {
 	font-weight: bold;
@@ -155,8 +160,6 @@
 .file.item .name, .file.item .name span {
 	color: black;
 	display: block;
-	width: 230px;
-	max-width: 230px;
 	/* Required for text-overflow to do anything */
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -171,6 +174,8 @@
 	right: 0px;
 	width: 32px;
 	height: 32px;
+	margin: 0px;
+	padding: 0px;
 }
 .file.item .errors::before {
 	color: var(--warning);


### PR DESCRIPTION
* Calc width for file tree item that has no error
* Calc width for file tree item that has an error (32px space for error icon)
* Recalc when you resize
* Has a minimum width of 60px on the tree-item text
* For items shorter then the remaining space the warning icon stays attached to the text
* It will work up to 7 sub-levels in the tree, afterwards it applies the width of the 7th level for sub-sequent levels

Maybe you can argue that limiting to 7-levels is not technically perfect. But there are also some limitations without adding too many custom css-classes to mark levels.

### Example screens 

## Default view
![image](https://user-images.githubusercontent.com/5152064/81046012-8bbc3100-8f0b-11ea-8fbf-c9c6c714da86.png)

## Resized to bigger
![image](https://user-images.githubusercontent.com/5152064/81046047-9e366a80-8f0b-11ea-9491-c5d640c13a67.png)

## Resized to max
![image](https://user-images.githubusercontent.com/5152064/81046068-b0b0a400-8f0b-11ea-8803-2a4cb5cffbc1.png)

## Resized to min
![image](https://user-images.githubusercontent.com/5152064/81046140-cf169f80-8f0b-11ea-828d-64d894e63cc1.png)
