### PR TITLE
OPENMEETINGS-2343 Menu header minor change to spacing and size 

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -385,7 +385,7 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	right: 2px;
 }
 .room-block .sb-wb .sidebar .tab.om-icon.big .label {
-	max-width: 45px;
+	max-width: 65px;
 	display: inline-block;
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -385,7 +385,7 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	right: 2px;
 }
 .room-block .sb-wb .sidebar .tab.om-icon.big .label {
-	max-width: 65px;
+	max-width: 60px;
 	display: inline-block;
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -374,7 +374,9 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 .room-block .sb-wb .sidebar .tab.om-icon.big {
 	line-height: 30px;
 	width: auto;
-	max-width: 80px;
+	padding-left: 10px;
+	min-width: 100px;
+	max-width: 120px;
 	position: relative;
 }
 .room-block .sb-wb .sidebar .tab .badge {
@@ -391,7 +393,9 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 }
 .room-block.narrow .sidebar .tab.om-icon.big {
 	max-width: 40px;
+	min-width: auto;
 	width: 40px;
+	padding-left: 6px;
 	padding-right: 0;
 }
 .room-block.narrow .sidebar .tab.om-icon.big .label {


### PR DESCRIPTION
Looking at the Tab Header they are rather small cut:
image.png
![image](https://user-images.githubusercontent.com/5152064/81148222-f9319580-8fcf-11ea-8cc5-4eeabfb1a789.png)

 - Blue icon with number of participants overlays User text
 - Files icon hardly fits inside

Is there any issue in making this bigger - as long as the tabs have enough space?

This PR changes it to display a bit more spacing around icon and text (if there is space):
![image](https://user-images.githubusercontent.com/5152064/81148272-149ca080-8fd0-11ea-9646-4bbd5a48e79d.png)

But then when it gets too small it still converts it into the mini version (as-is behaviour)
![image](https://user-images.githubusercontent.com/5152064/81148310-29793400-8fd0-11ea-94ec-e3d64b3c14c5.png)

Should be a simple PR I think.