### PR TITLE
OPENMEETINGS-2347 Fix to apply width based on sidebar same as in room.

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-variables.css
+++ b/openmeetings-web/src/main/webapp/css/raw-variables.css
@@ -4,6 +4,7 @@ body {
 	--menu-height: 36px;
 	--level-color: #ADFF2F;
 	--rooms-header-height: 70px;
+	--room-sidebar-width: 315px;
 	--tabs-height: 45px;
 	--buffer-size: 4px;
 	--menu-zindex: 10000000;


### PR DESCRIPTION
Simple fix. But does the job for now:
![image](https://user-images.githubusercontent.com/5152064/81487716-2756f400-92b4-11ea-84d3-d5f73fb0f142.png)

Would be good to introduce resizing the panel. But maybe that is a future. Especially since the name of the recording can't be edited right now. So you won't exceed width unless you do nested folders.