### PR TITLE
[OPENMEETINGS-2349] new chromium-edge detection method and fixes

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
@@ -87,7 +87,7 @@ var Sharer = (function() {
 	}
 	function _typeDisabled(_b) {
 		const b = _b || kurentoUtils.WebRtcPeer.browser;
-		return VideoUtil.isEdge(b) || VideoUtil.isChrome(b);
+		return VideoUtil.isEdge(b) || VideoUtil.isChrome(b) || VideoUtil.isEdgeChromium(b);
 	}
 	function _setBtnState(btn, state) {
 		const dis = SHARE_STOPPED !== state

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video-util.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video-util.js
@@ -211,7 +211,11 @@ var VideoUtil = (function() {
 	}
 	function _isEdge(_b) {
 		const b = _b || kurentoUtils.WebRtcPeer.browser;
-		return b.name === 'Edge';
+		return b.name === 'Edge' && "MSGestureEvent" in window;
+	}
+	function _isEdgeChromium(_b) {
+		const b = _b || kurentoUtils.WebRtcPeer.browser;
+		return b.name === 'Edge' && !("MSGestureEvent" in window);
 	}
 	function _setPos(v, pos) {
 		if (v.dialog('instance')) {
@@ -288,6 +292,7 @@ var VideoUtil = (function() {
 		return opts;
 	};
 	self.isEdge = _isEdge;
+	self.isEdgeChromium = _isEdgeChromium;
 	self.isChrome = _isChrome;
 	self.setPos = _setPos;
 	self.askPermission = _askPermission;

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video.js
@@ -32,17 +32,13 @@ var Video = (function() {
 			cnts = {
 				video: true
 			};
-			if (b.major > 80) {
-				promise = navigator.mediaDevices.getDisplayMedia(cnts);
-			} else {
-				promise = navigator.getDisplayMedia(cnts);
-			}
+			promise = navigator.getDisplayMedia(cnts);
 		} else if (b.name === 'Firefox') {
 			// https://mozilla.github.io/webrtc-landing/gum_test.html
 			cnts = Sharer.baseConstraints(sd);
 			cnts.video.mediaSource = sd.shareType;
 			promise = navigator.mediaDevices.getUserMedia(cnts);
-		} else if (VideoUtil.isChrome(b)) {
+		} else if (VideoUtil.isChrome(b) || VideoUtil.isEdgeChromium(b)) {
 			cnts = {
 				video: true
 			};


### PR DESCRIPTION
 - versioning for edge browsers is inconsistent across platforms and is unreliable for differentiation between EdgeHTML and Blink engines
 - introduce new VideoUtil.isEdgeChromium and check in both isEdge and isEdgeChromium if EdgeHTML's exclusive MSGestureEvent is available
 - this will also fix wrong audio destination issue