### PR TITLE
OPENMEETINGS-2339 Fix issue around icons hidden behind drag for video pod

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-video.js
@@ -287,7 +287,7 @@ var Video = (function() {
 			});
 		}
 		v.parent().find('.ui-dialog-titlebar-close').remove();
-		v.parent().find('.ui-dialog-titlebar').append(OmUtil.tmpl('#video-button-bar'));
+		v.parent().append(OmUtil.tmpl('#video-button-bar'));
 		const refresh = v.parent().find('.btn-refresh')
 			, tgl = v.parent().find('.btn-toggle')
 			, cls = v.parent().find('.btn-wclose');

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -425,11 +425,11 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 .user-video .ui-dialog-titlebar
 , .sharer .ui-dialog-titlebar
 , .wb-tool-settings .ui-dialog-titlebar
-, .user-video .ui-dialog-titlebar .buttonpane
 {
 	background-color: var(--white);
 }
-.user-video .ui-dialog-titlebar .buttonpane {
+.user-video .buttonpane {
+	background-color: var(--white);
 	position: absolute;
 	right: 2px;
 	top: 2px


### PR DESCRIPTION
This fix moves the icons on top of the drag element.
By doing this you can drag it on mobile touch _and_ yo ucan still click the icons.

This fixes the issue that on mobile/touch devices you can't click on the icons as the DIV with the ui-titlebar is on top.

This is similar to the fix as suggest by @solomax in the Jira. 