### PR TITLE
OPENMEETINGS-2339 Fix sharer window for touch surface close icon clone.

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
@@ -26,6 +26,16 @@ var Sharer = (function() {
 			, autoOpen: false
 			, resizable: false
 		});
+		
+		// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
+		// touch-events are broken and you won't be able to close the dialog
+		var closeIcon = sharer.parent().find('.ui-dialog-titlebar-close').clone();
+		sharer.parent().append(closeIcon);
+		sharer.parent().find('.ui-dialog-titlebar-close').first().remove();
+		sharer.parent().find('.ui-dialog-titlebar-close').click(function() {
+			sharer.dialog('close');
+		});
+		
 		if (!VideoUtil.sharingSupported()) {
 			sharer.find('.container').remove();
 			sharer.find('.alert').show();

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
@@ -29,12 +29,7 @@ var Sharer = (function() {
 		
 		// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
 		// touch-events are broken and you won't be able to close the dialog
-		var closeIcon = sharer.parent().find('.ui-dialog-titlebar-close').clone();
-		sharer.parent().append(closeIcon);
-		sharer.parent().find('.ui-dialog-titlebar-close').first().remove();
-		sharer.parent().find('.ui-dialog-titlebar-close').click(function() {
-			sharer.dialog('close');
-		});
+		sharer.parent().find('.ui-dialog-titlebar-close').appendTo(sharer.parent())
 		
 		if (!VideoUtil.sharingSupported()) {
 			sharer.find('.container').remove();

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
@@ -29,7 +29,7 @@ var Sharer = (function() {
 		
 		// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
 		// touch-events are broken and you won't be able to close the dialog
-		sharer.parent().find('.ui-dialog-titlebar-close').appendTo(sharer.parent())
+		sharer.parent().find('.ui-dialog-titlebar-close').appendTo(sharer.parent());
 		
 		if (!VideoUtil.sharingSupported()) {
 			sharer.find('.container').remove();

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -429,6 +429,10 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 {
 	background-color: var(--white);
 }
+.sharer .ui-dialog-titlebar-close {
+	position: absolute;
+	top: 20px
+}
 .user-video .ui-dialog-titlebar .buttonpane {
 	position: absolute;
 	right: 2px;


### PR DESCRIPTION
Thats following the approach of having a separated div in top of the draggable DIV in order to make the close icon clickable on touch surface: Cloning existing one and moving it one layer up.