### PR TITLE
OPENMEETINGS-2357 Add handle for draggable and move close icon outside titlebar

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -195,12 +195,12 @@
 		<div id="wb-formula" class="wb-formula ui-corner-all ui-widget-content">
 			<div wicket:message="title:wb.tool.math.formula" class="header ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix ui-draggable-handle">
 				<span class="ui-dialog-title"><wicket:message key="wb.tool.math.formula"/></span>
-				<button type="button" class="ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close" wicket:message="title:85">
-					<span class="ui-button-icon ui-icon ui-icon-closethick"></span>
-					<span class="ui-button-icon-space"> </span>
-					<wicket:message key="85"/>
-				</button>
 			</div>
+			<button type="button" class="ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close" wicket:message="title:85">
+				<span class="ui-button-icon ui-icon ui-icon-closethick"></span>
+				<span class="ui-button-icon-space"> </span>
+				<wicket:message key="85"/>
+			</button>
 			<div class="text-container"><textarea></textarea></div>
 			<div>
 				<a class="latex-guide" wicket:message="href:wb.tool.math.guide.url" target="_blank"><wicket:message key="wb.tool.math.guide.lbl"/></a>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-board.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-board.js
@@ -351,6 +351,7 @@ var Wb = function() {
 				}).parent().css('text-align', Settings.isRtl ? 'left' : 'right');
 				math.draggable({
 					scroll: false
+					, handle: '.ui-dialog-titlebar'
 					, containment: 'body'
 					, start: function() {
 						if (!!math.css('bottom')) {
@@ -362,7 +363,8 @@ var Wb = function() {
 							return false;
 						}
 					}
-				}).resizable({
+				});
+				math.resizable({
 					alsoResize: math.find('.text-container')
 				});
 			case NONE:


### PR DESCRIPTION
Actually this dialog didn't work on Mobile/Touch at all: The draggable was applied to the entire DIV. Which meant on mobile: You can't actually click into the text area. 
So basically this dialog was neither possible to close, nor could you do anything with it, cause not possible to enter text.