### PR TITLE
OPENMEETINGS-2308 Re-add accidentally merged out of the code CSS from video pod fix

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -432,7 +432,8 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	position: absolute;
 	top: 20px
 }
-.user-video .ui-dialog-titlebar .buttonpane {
+.user-video .buttonpane {
+	background-color: var(--white);
 	position: absolute;
 	right: 2px;
 	top: 2px


### PR DESCRIPTION
I accidentally reverted this CSS when merging the fix for the sharer and the video pod buttons.
Now it works as expected.