### PR TITLE
OPENMEETINGS-2360 Fix draggable on ui-titlebar and button to close outside of it

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -163,12 +163,12 @@
 		<div id="wb-tool-settings" class="wb-tool-settings ui-widget-content">
 			<div wicket:message="title:843" class="header ui-dialog-titlebar ui-widget-header ui-helper-clearfix ui-draggable-handle">
 				<span class="ui-dialog-title"><wicket:message key="843"/></span>
-				<button type="button" class="ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close" wicket:message="title:85">
-					<span class="ui-button-icon ui-icon ui-icon-closethick"></span>
-					<span class="ui-button-icon-space"> </span>
-					<wicket:message key="85"/>
-				</button>
 			</div>
+			<button type="button" class="ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close" wicket:message="title:85">
+				<span class="ui-button-icon ui-icon ui-icon-closethick"></span>
+				<span class="ui-button-icon-space"> </span>
+				<wicket:message key="85"/>
+			</button>
 			<div class="tab props">
 				<div class="prop-row">
 					<div class="block lbl" wicket:message="title:546"><wicket:message key="545"/></div>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-board.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-board.js
@@ -242,6 +242,7 @@ var Wb = function() {
 		});
 		settings.draggable({
 			scroll: false
+			, handle: '.ui-dialog-titlebar'
 			, containment: 'body'
 			, start: function() {
 				if (!!settings.css('bottom')) {


### PR DESCRIPTION
Fixes that on mobile/touch surface you can:
 - Close the dialog again
 - can click inside any of the text boxes or colors pickers or buttons

Still retains draggable.
I did not see any drawbacks.