### PR TITLE
OPENMEETINGS-2356 Move close icon on top of ui-titlebar so that mobile and touch can click it

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/main.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/common/main.js
@@ -132,6 +132,11 @@ Wicket.BrowserInfo.collectExtraInfo = function(info) {
 	info.codebase = l.origin + l.pathname;
 	info.settings = Settings.load();
 };
+//Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
+// touch-events are broken and you won't be able to close the dialog
+function fixJQueryUIDialogTouch (dialog) {
+    dialog.parent().find('.ui-dialog-titlebar-close').appendTo(dialog.parent());
+}
 function showBusyIndicator() {
 	$('#busy-indicator').show();
 }

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/raw-sharer.js
@@ -26,10 +26,7 @@ var Sharer = (function() {
 			, autoOpen: false
 			, resizable: false
 		});
-		
-		// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
-		// touch-events are broken and you won't be able to close the dialog
-		sharer.parent().find('.ui-dialog-titlebar-close').appendTo(sharer.parent());
+		fixJQueryUIDialogTouch(sharer);
 		
 		if (!VideoUtil.sharingSupported()) {
 			sharer.find('.container').remove();

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
@@ -411,6 +411,10 @@ var DrawWbArea = function() {
 					width: 350
 					, appendTo: '.room-block .wb-block'
 				});
+				// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
+				// touch-events are broken and you won't be able to close the dialog
+				dlg.parent().find('.ui-dialog-titlebar-close').appendTo(dlg.parent());
+				
 			} catch (e) {
 				console.error(e);
 			}

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/raw-wb-area.js
@@ -411,10 +411,7 @@ var DrawWbArea = function() {
 					width: 350
 					, appendTo: '.room-block .wb-block'
 				});
-				// Fix to move the close icon on top of the .ui-dialog-titlebar cause otherwise 
-				// touch-events are broken and you won't be able to close the dialog
-				dlg.parent().find('.ui-dialog-titlebar-close').appendTo(dlg.parent());
-				
+				fixJQueryUIDialogTouch(dlg);
 			} catch (e) {
 				console.error(e);
 			}

--- a/openmeetings-web/src/main/webapp/css/theme_om/jquery-ui.css
+++ b/openmeetings-web/src/main/webapp/css/theme_om/jquery-ui.css
@@ -596,7 +596,7 @@ button.ui-button::-moz-focus-inner {
 .ui-dialog .ui-dialog-titlebar-close {
 	position: absolute;
 	right: 10px;
-    top: 20px;
+	top: 20px;
 	width: 20px;
 	margin: -10px 0 0 0;
 	padding: 1px;

--- a/openmeetings-web/src/main/webapp/css/theme_om/jquery-ui.css
+++ b/openmeetings-web/src/main/webapp/css/theme_om/jquery-ui.css
@@ -595,8 +595,8 @@ button.ui-button::-moz-focus-inner {
 }
 .ui-dialog .ui-dialog-titlebar-close {
 	position: absolute;
-	right: .3em;
-	top: 50%;
+	right: 10px;
+    top: 20px;
 	width: 20px;
 	margin: -10px 0 0 0;
 	padding: 1px;


### PR DESCRIPTION
Moving close icon on top.
Although this dialog does not make much sense for Mobile/Touch cause it says "right click and save as" => You can't right click on Mobile devices on anything. 

Anyway, I added another ticket for that, this PR/ticket just fixes so that you can at least close the dialog.