### PR TITLE
OPENMEETINGS-2470 Fix and remove filters while running in dev version.

### DIFF
--- a/openmeetings-web/pom.xml
+++ b/openmeetings-web/pom.xml
@@ -554,6 +554,7 @@
 						</systemProperties>
 						<webApp>
 							<contextPath>/openmeetings</contextPath>
+							<descriptor>${project.basedir}/src/test/jetty/web.xml</descriptor>
 						</webApp>
 						<jettyXml>${project.basedir}/src/test/jetty/jetty.xml,${project.basedir}/src/test/jetty/jetty-ssl.xml,${project.basedir}/src/test/jetty/jetty-http.xml,${project.basedir}/src/test/jetty/jetty-https.xml</jettyXml>
 					</configuration>

--- a/openmeetings-web/src/test/jetty/web.xml
+++ b/openmeetings-web/src/test/jetty/web.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+-->
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+	<context-param>
+		<param-name>contextConfigLocation</param-name>
+		<param-value>/WEB-INF/classes/applicationContext.xml</param-value>
+	</context-param>
+	<context-param>
+		<param-name>org.apache.tomcat.websocket.textBufferSize</param-name>
+		<param-value>1048576</param-value> <!-- 1MB by default -->
+	</context-param>
+	<listener>
+		<listener-class>org.apache.openmeetings.util.OMContextListener</listener-class>
+	</listener>
+
+	<filter>
+		<filter-name>OpenmeetingsApplication</filter-name>
+		<filter-class>org.apache.wicket.protocol.ws.javax.JavaxWebSocketFilter</filter-class>
+		<async-supported>true</async-supported>
+		<init-param>
+			<param-name>applicationClassName</param-name>
+			<param-value>org.apache.openmeetings.web.app.Application</param-value>
+		</init-param>
+		<init-param>
+			<param-name>applicationFactoryClassName</param-name>
+			<param-value>org.apache.wicket.spring.SpringWebApplicationFactory</param-value>
+		</init-param>
+		<init-param>
+			<param-name>configuration</param-name>
+			<param-value>${wicket.configuration}</param-value>
+		</init-param>
+		<init-param>
+			<param-name>ignorePaths</param-name>
+			<param-value>css,docs,images,js,persistence,public,screenshare,data,services</param-value>
+		</init-param>
+	</filter>
+	<filter-mapping>
+		<filter-name>OpenmeetingsApplication</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
+	<listener>
+		<listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+	</listener>
+
+	<servlet>
+		<servlet-name>CXFServlet</servlet-name>
+		<servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
+		<init-param>
+			<param-name>config-location</param-name>
+			<param-value>classpath:cxf-servlet.xml</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+		<async-supported>true</async-supported>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>CXFServlet</servlet-name>
+		<url-pattern>/services/*</url-pattern>
+	</servlet-mapping>
+
+	<mime-mapping>
+		<extension>inc</extension>
+		<mime-type>text/plain</mime-type>
+	</mime-mapping>
+
+</web-app>


### PR DESCRIPTION
This supplies a dev version for the web.xml that does not filter/security.

Jetty filter restrictions look different from Tomcat, so the effect before this change was that if you try to access WebService when running in Jetty was that you always get a 403.

With this change the filters are removed and everything is public readable.

But: Since jetty is only used in dev mode, I think that is fine.