### PR TITLE
Feature expand chat panel width by clicking on title

### DIFF
--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application.properties.xml
@@ -827,6 +827,7 @@ see https://openmeetings.apache.org/LanguageEditor.html for Details
 please check <tt>openmeetings.log</tt> and contact OpenMeetings developers]]></entry>
 	<entry key="invalid.hash"><![CDATA[Invalid hash]]></entry>
 	<entry key="label.dock.panel"><![CDATA[Click to dock panel]]></entry>
+	<entry key="label.exdock.panel"><![CDATA[Click to expand dock panel]]></entry>
 	<entry key="label.undock.panel"><![CDATA[Click to undock panel]]></entry>
 	<entry key="lbl.cancel"><![CDATA[Cancel]]></entry>
 	<entry key="lbl.email"><![CDATA[Email]]></entry>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/user/chat/ChatPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/user/chat/ChatPanel.html
@@ -21,7 +21,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
 	<div id="chatPopup" class="bg-light">
-		<div class="control block clickable bg-secondary" wicket:message="data-ttl-dock:label.dock.panel,data-ttl-undock:label.undock.panel">
+		<div class="control block clickable bg-secondary" wicket:message="data-ttl-dock:label.dock.panel,data-ttl-undock:label.undock.panel,data-ttl-exdock:label.exdock.panel">
 			<i class="fas ml-1"></i>
 			<div class="label"><wicket:message key="244"/></div>
 		</div>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/user/chat/raw-chat.js
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/user/chat/raw-chat.js
@@ -119,8 +119,11 @@ var Chat = function() {
 	function isClosed() {
 		return p.hasClass('closed');
 	}
+	function isWide() {
+		return p.hasClass('wide');
+	}
 	function activateTab(id) {
-		if (isClosed()) {
+		if (isClosed() || isWide()) {
 			tabs.find('.nav.nav-tabs .nav-link').each(function() {
 				const self = $(this)
 					, tabId = self.attr('aria-controls')
@@ -353,9 +356,49 @@ var Chat = function() {
 			}
 		});
 	}
+	function _setOpenedw() {
+		__setCssWidth(innerWidth);
+		p.addClass('wide').css({'height': '', 'width': ''});
+		p.resizable({
+			handles: (Settings.isRtl ? 'e' : 'w')
+			, minWidth: 120
+			, stop: function(event, ui) {
+				p.css({'left': '', 'width': '', 'height': ''});
+				openedWidth = ui.size.width + 'px';
+				__setCssWidth(openedWidth);
+			}
+		});
+	}
 	function _removeResize() {
 		if (p.resizable('instance') !== undefined) {
 			p.resizable('destroy');
+		}
+	}
+	function _openw(handler) {
+		if (!isClosed() && !isWide()) {
+			//ctrl.removeClass('bg-warning');
+			let opts;
+			if (roomMode) {
+				opts = {width: innerWidth};
+			} else {
+				opts = {height: openedHeight};
+				p.resizable("option", "disabled", false);
+			}
+			p.removeClass('closed').animate(opts, 1000, function() {
+				__hideActions();
+				p.removeClass('closed');
+				p.css({'height': '', 'width': ''});
+				if (typeof(handler) === 'function') {
+					handler();
+				}
+				ctrl.attr('title', ctrl.data('ttl-undock'));
+				if (roomMode) {
+					_setOpenedw();
+				} else {
+					__setCssHeight(openedHeight);
+				}
+				_setAreaHeight();
+			});
 		}
 	}
 	function _open(handler) {
@@ -375,7 +418,7 @@ var Chat = function() {
 				if (typeof(handler) === 'function') {
 					handler();
 				}
-				ctrl.attr('title', ctrl.data('ttl-undock'));
+				ctrl.attr('title', ctrl.data('ttl-exdock'));
 				if (roomMode) {
 					_setOpened();
 				} else {
@@ -396,6 +439,7 @@ var Chat = function() {
 			}
 			p.animate(opts, 1000, function() {
 				p.addClass('closed').css({'height': '', 'width': ''});
+				p.removeClass('wide');
 				if (roomMode) {
 					__setCssWidth(closedSizePx);
 					_removeResize();
@@ -412,8 +456,10 @@ var Chat = function() {
 	function _toggle() {
 		if (isClosed()) {
 			_open();
-		} else {
+		} else if (isWide()) {
 			_close();
+		} else {
+			_openw();
 		}
 	}
 	function _editorAppend(emoticon) {

--- a/openmeetings-web/src/main/webapp/css/raw-chat.css
+++ b/openmeetings-web/src/main/webapp/css/raw-chat.css
@@ -47,9 +47,15 @@
 	content: "\f106";
 }
 .main.room #chatPanel #chatPopup .control.block i::before {
-	content: "\f105";
+	content: "\f104\f104";
 }
 .main.room #chatPanel.closed #chatPopup .control.block i::before {
+	content: "\f104";
+}
+.main.room #chatPanel.wide #chatPopup .control.block i::before {
+	content: "\f105";
+}
+.main.room #chatPanel.opened #chatPopup .control.block i::before {
 	content: "\f104";
 }
 #chat .messageArea .msg-row.need-moderation {


### PR DESCRIPTION
When OpenMeeting is used on mobile devices, the chat panel can't change width since it can't drag a mouse on mobile devices. 
By this feature by clicking on the chat title user can expand the width of the chat window for max width of windows. 
Real examples on these images:
![OM01](https://user-images.githubusercontent.com/9219334/98309400-fb9e9780-1fd2-11eb-99c5-27f16a393931.png)
![OM02](https://user-images.githubusercontent.com/9219334/98309401-fc372e00-1fd2-11eb-875c-1ee252048554.png)
![OM03](https://user-images.githubusercontent.com/9219334/98309403-fccfc480-1fd2-11eb-9cb0-d39eb7608643.png)
![OM04](https://user-images.githubusercontent.com/9219334/98309405-fd685b00-1fd2-11eb-9408-c3841f8b7d25.png)
