### PR TITLE
OPENMEETINGS-2560 Improve response to return the actual error to client.

### DIFF
--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/BaseWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/BaseWebService.java
@@ -75,11 +75,13 @@ public abstract class BaseWebService {
 		return new HashSet<>();
 	}
 
-	<T> T performCall(String sid, User.Right level, Function<Sessiondata, T> action) {
+	<T> T performCall(String sid, User.Right level, Function<Sessiondata, T> action) throws ServiceException {
 		return performCall(sid, sd -> AuthLevelUtil.check(getRights(sd.getUserId()), level), action);
 	}
 
-	<T> T performCall(String sid, Predicate<Sessiondata> allowed, Function<Sessiondata, T> action) {
+	<T> T performCall(String sid, Predicate<Sessiondata> allowed, Function<Sessiondata, T> action)
+			throws ServiceException
+	{
 		try {
 			Sessiondata sd = check(sid);
 			if (allowed.test(sd)) {

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/CalendarWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/CalendarWebService.java
@@ -48,6 +48,7 @@ import org.apache.openmeetings.db.entity.calendar.Appointment;
 import org.apache.openmeetings.db.entity.user.User;
 import org.apache.openmeetings.db.entity.user.User.Right;
 import org.apache.openmeetings.db.util.AuthLevelUtil;
+import org.apache.openmeetings.webservice.error.InternalServiceException;
 import org.apache.openmeetings.webservice.error.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,13 +85,14 @@ public class CalendarWebService extends BaseWebService {
 	 *            end time
 	 *
 	 * @return - list of appointments in range
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/{start}/{end}")
 	public List<AppointmentDTO> range(@QueryParam("sid") @WebParam(name="sid") String sid
 			, @PathParam("start") @WebParam(name="start") Calendar start
 			, @PathParam("end") @WebParam(name="end") Calendar end
-			)
+			) throws ServiceException
 	{
 		log.debug("range : startdate - {} , enddate - {}"
 				, start == null ? "" : start.getTime()
@@ -112,6 +114,7 @@ public class CalendarWebService extends BaseWebService {
 	 *            end time
 	 *
 	 * @return - list of appointments in range
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/{userid}/{start}/{end}")
@@ -120,7 +123,7 @@ public class CalendarWebService extends BaseWebService {
 			, @PathParam("userid") @WebParam(name="userid") long userid
 			, @PathParam("start") @WebParam(name="start") Calendar start
 			, @PathParam("end") @WebParam(name="end") Calendar end
-			)
+			) throws ServiceException
 	{
 		log.debug("rangeForUser : startdate - {} , enddate - {}"
 				, start == null ? "" : start.getTime()
@@ -135,10 +138,11 @@ public class CalendarWebService extends BaseWebService {
 	 * @param sid
 	 *            The SID of the User. This SID must be marked as Loggedin
 	 * @return - next Calendar event
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/next")
-	public AppointmentDTO next(@QueryParam("sid") @WebParam(name="sid") String sid) {
+	public AppointmentDTO next(@QueryParam("sid") @WebParam(name="sid") String sid) throws ServiceException {
 		return performCall(sid, User.Right.ROOM, sd -> {
 			Appointment a = dao.getNext(sd.getUserId(), new Date());
 			return a == null ? null : new AppointmentDTO(a);
@@ -154,10 +158,14 @@ public class CalendarWebService extends BaseWebService {
 	 *            the userId the calendar events should be loaded
 	 *
 	 * @return - next Calendar event
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/next/{userid}")
-	public AppointmentDTO nextForUser(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("userid") @WebParam(name="userid") long userid) {
+	public AppointmentDTO nextForUser(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("userid") @WebParam(name="userid") long userid
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Appointment a = dao.getNext(userid, new Date());
 			return a == null ? null : new AppointmentDTO(a);
@@ -173,10 +181,14 @@ public class CalendarWebService extends BaseWebService {
 	 * @param roomid
 	 *            id of appointment special room
 	 * @return - calendar event by its room id
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/room/{roomid}")
-	public AppointmentDTO getByRoom(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("roomid") @WebParam(name="roomid") long roomid) {
+	public AppointmentDTO getByRoom(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("roomid") @WebParam(name="roomid") long roomid
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.ROOM, sd -> {
 			Appointment a = dao.getByRoom(sd.getUserId(), roomid);
 			return a == null ? null : new AppointmentDTO(a);
@@ -192,10 +204,14 @@ public class CalendarWebService extends BaseWebService {
 	 *            the search string
 	 *
 	 * @return - calendar event list
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/title/{title}")
-	public List<AppointmentDTO> getByTitle(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("title") @WebParam(name="title") String title) {
+	public List<AppointmentDTO> getByTitle(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("title") @WebParam(name="title") String title
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.ROOM, sd -> AppointmentDTO.list(dao.searchByTitle(sd.getUserId(), title)));
 	}
 
@@ -208,11 +224,15 @@ public class CalendarWebService extends BaseWebService {
 	 *            calendar event
 	 *
 	 * @return - appointment saved
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@POST
 	@Path("/")
-	public AppointmentDTO save(@QueryParam("sid") @WebParam(name="sid") String sid, @FormParam("appointment") @WebParam(name="appointment") AppointmentDTO appointment) {
+	public AppointmentDTO save(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @FormParam("appointment") @WebParam(name="appointment") AppointmentDTO appointment
+			) throws ServiceException
+	{
 		//Seems to be create
 		log.debug("save SID: {}", sid);
 
@@ -253,10 +273,14 @@ public class CalendarWebService extends BaseWebService {
 	 * @param id
 	 *            the id to delete
 	 * @return {@link ServiceResult} with result type
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@DELETE
 	@Path("/{id}")
-	public ServiceResult delete(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("id") @WebParam(name="id") Long id) {
+	public ServiceResult delete(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("id") @WebParam(name="id") Long id
+			) throws ServiceException
+	{
 		Appointment a = dao.get(id);
 		return performCall(sid, sd -> {
 				Set<Right> rights = getRights(sd.getUserId());
@@ -270,7 +294,7 @@ public class CalendarWebService extends BaseWebService {
 				return false;
 			}, sd -> {
 				if (a == null) {
-					throw new ServiceException("Bad id");
+					throw new InternalServiceException("Bad id");
 				}
 				dao.delete(a, sd.getUserId());
 				return new ServiceResult("Deleted", Type.SUCCESS);

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/GroupWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/GroupWebService.java
@@ -50,6 +50,7 @@ import org.apache.openmeetings.db.entity.room.RoomGroup;
 import org.apache.openmeetings.db.entity.user.Group;
 import org.apache.openmeetings.db.entity.user.GroupUser;
 import org.apache.openmeetings.db.entity.user.User;
+import org.apache.openmeetings.webservice.error.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,10 +85,14 @@ public class GroupWebService extends BaseWebService {
 	 * @param name
 	 *            the name of the group
 	 * @return {@link ServiceResult} with result type, and id of the group added
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@POST
 	@Path("/")
-	public ServiceResult add(@QueryParam("sid") @WebParam(name="sid") String sid, @QueryParam("name") @WebParam(name="name") String name) {
+	public ServiceResult add(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @QueryParam("name") @WebParam(name="name") String name
+			) throws ServiceException
+	{
 		log.debug("add:: name {}", name);
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Group o = new Group();
@@ -102,10 +107,11 @@ public class GroupWebService extends BaseWebService {
 	 * @param sid
 	 *            The SID from getSession
 	 * @return list of all groups
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/")
-	public List<GroupDTO> get(@QueryParam("sid") @WebParam(name="sid") String sid) {
+	public List<GroupDTO> get(@QueryParam("sid") @WebParam(name="sid") String sid) throws ServiceException {
 		return performCall(sid, User.Right.SOAP, sd -> GroupDTO.list(groupDao.get(0, Integer.MAX_VALUE)));
 	}
 
@@ -120,6 +126,7 @@ public class GroupWebService extends BaseWebService {
 	 * @param id
 	 *            the group id
 	 * @return {@link ServiceResult} with result type, and id of the USER added, or error id in case of the error as text
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@POST
 	@Path("/{id}/users/{userid}")
@@ -127,7 +134,7 @@ public class GroupWebService extends BaseWebService {
 			@QueryParam("sid") @WebParam(name="sid") String sid
 			, @PathParam("id") @WebParam(name="id") Long id
 			, @PathParam("userid") @WebParam(name="userid") Long userid
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			if (!groupUserDao.isUserInGroup(id, userid)) {
@@ -150,6 +157,7 @@ public class GroupWebService extends BaseWebService {
 	 * @param id
 	 *            the group id
 	 * @return {@link ServiceResult} with result type, and id of the USER added, or error id in case of the error as text
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@DELETE
 	@Path("/{id}/users/{userid}")
@@ -157,7 +165,7 @@ public class GroupWebService extends BaseWebService {
 			@QueryParam("sid") @WebParam(name="sid") String sid
 			, @PathParam("id") @WebParam(name="id") Long id
 			, @PathParam("userid") @WebParam(name="userid") Long userid
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			if (groupUserDao.isUserInGroup(id, userid)) {
@@ -182,6 +190,7 @@ public class GroupWebService extends BaseWebService {
 	 * @param roomid - Id of room to be added
 	 *
 	 * @return {@link ServiceResult} with result type
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@POST
 	@Path("/{id}/rooms/add/{roomid}")
@@ -189,7 +198,7 @@ public class GroupWebService extends BaseWebService {
 			@QueryParam("sid") @WebParam(name="sid") String sid
 			, @PathParam("id") @WebParam(name="id") Long id
 			, @PathParam("roomid") @WebParam(name="roomid") Long roomid
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Room r = roomDao.get(roomid);
@@ -229,6 +238,7 @@ public class GroupWebService extends BaseWebService {
 	 * @param asc
 	 *            asc or desc
 	 * @return - users found
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@GET
 	@Path("/users/{id}")
@@ -239,7 +249,7 @@ public class GroupWebService extends BaseWebService {
 			, @QueryParam("max") @WebParam(name="max") int max
 			, @QueryParam("orderby") @WebParam(name="orderby") String orderby
 			, @QueryParam("asc") @WebParam(name="asc") boolean asc
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			SearchResult<User> result = new SearchResult<>();
@@ -262,11 +272,15 @@ public class GroupWebService extends BaseWebService {
 	 * @param id
 	 *            the id of the group
 	 * @return {@link ServiceResult} with result type
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@DELETE
 	@Path("/{id}")
-	public ServiceResult delete(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="id") @PathParam("id") long id) {
+	public ServiceResult delete(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="id") @PathParam("id") long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.ADMIN, sd -> {
 			groupDao.delete(groupDao.get(id), sd.getUserId());
 

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/RecordingWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/RecordingWebService.java
@@ -39,6 +39,7 @@ import org.apache.openmeetings.db.dto.basic.ServiceResult;
 import org.apache.openmeetings.db.dto.basic.ServiceResult.Type;
 import org.apache.openmeetings.db.dto.record.RecordingDTO;
 import org.apache.openmeetings.db.entity.user.User;
+import org.apache.openmeetings.webservice.error.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,10 +72,14 @@ public class RecordingWebService extends BaseWebService {
 	 *            the id of the recording
 	 *
 	 * @return {@link ServiceResult} with result type
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@DELETE
 	@Path("/{id}")
-	public ServiceResult delete(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("id") @WebParam(name="id") Long id) {
+	public ServiceResult delete(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("id") @WebParam(name="id") Long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			recordingDao.delete(recordingDao.get(id));
 			return new ServiceResult("Deleted", Type.SUCCESS);
@@ -89,13 +94,16 @@ public class RecordingWebService extends BaseWebService {
 	 * @param externalType the externalUserType
 	 *
 	 * @return - list of recordings
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/{externaltype}/{externalid}")
 	public List<RecordingDTO> getExternal(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @PathParam("externaltype") @WebParam(name="externaltype") String externalType
-			, @PathParam("externalid") @WebParam(name="externalid") String externalId) {
+			, @PathParam("externalid") @WebParam(name="externalid") String externalId
+			) throws ServiceException
+	{
 		log.debug("getExternal:: type {}, id {}", externalType, externalId);
 		return performCall(sid, User.Right.SOAP, sd -> RecordingDTO.list(recordingDao.getByExternalUser(externalId, externalType)));
 	}
@@ -108,12 +116,15 @@ public class RecordingWebService extends BaseWebService {
 	 * @param externalType
 	 *            externalType specified when creating the room
 	 * @return - list of flv recordings
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/{externaltype}")
 	public List<RecordingDTO> getExternalByType(@WebParam(name="sid") @QueryParam("sid") String sid
-			, @PathParam("externaltype") @WebParam(name="externaltype") String externalType) {
+			, @PathParam("externaltype") @WebParam(name="externaltype") String externalType
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> RecordingDTO.list(recordingDao.getByExternalType(externalType)));
 	}
 
@@ -125,12 +136,15 @@ public class RecordingWebService extends BaseWebService {
 	 * @param roomId
 	 *            the room id
 	 * @return - list of recordings
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/room/{roomid}")
 	public List<RecordingDTO> getExternalByRoom(@WebParam(name="sid") @QueryParam("sid") String sid
-			, @PathParam("roomid") @WebParam(name="roomid") Long roomId) {
+			, @PathParam("roomid") @WebParam(name="roomid") Long roomId
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> RecordingDTO.list(recordingDao.getByRoomId(roomId)));
 	}
 }

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/RoomWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/RoomWebService.java
@@ -56,6 +56,7 @@ import org.apache.openmeetings.db.manager.IClientManager;
 import org.apache.openmeetings.db.manager.IWhiteboardManager;
 import org.apache.openmeetings.db.util.ws.RoomMessage;
 import org.apache.openmeetings.service.room.InvitationManager;
+import org.apache.openmeetings.webservice.error.InternalServiceException;
 import org.apache.openmeetings.webservice.error.ServiceException;
 import org.apache.wicket.util.string.Strings;
 import org.slf4j.Logger;
@@ -101,11 +102,15 @@ public class RoomWebService extends BaseWebService {
 	 * @param type
 	 *            Type of public rooms need to be retrieved
 	 * @return - list of public rooms
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/public/{type}")
-	public List<RoomDTO> getPublic(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("type") @WebParam(name="type") String type) {
+	public List<RoomDTO> getPublic(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("type") @WebParam(name="type") String type
+			) throws ServiceException
+	{
 		Room.Type t = Strings.isEmpty(type) ? null : Room.Type.valueOf(type);
 		return performCall(sid, User.Right.ROOM, sd -> RoomDTO.list(roomDao.getPublicRooms(t)));
 	}
@@ -116,11 +121,15 @@ public class RoomWebService extends BaseWebService {
 	 * @param sid - The SID of the User. This SID must be marked as Loggedin
 	 * @param id - the room id
 	 * @return - room with the id given
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/{id}")
-	public RoomDTO getRoomById(@QueryParam("sid") @WebParam(name="sid") String sid, @PathParam("id") @WebParam(name="id") Long id) {
+	public RoomDTO getRoomById(@QueryParam("sid") @WebParam(name="sid") String sid
+			, @PathParam("id") @WebParam(name="id") Long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> new RoomDTO(roomDao.get(id)));
 	}
 
@@ -161,6 +170,7 @@ public class RoomWebService extends BaseWebService {
 	 *            details of the room to be created if not found
 	 *
 	 * @return - id of the room or error code
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
@@ -169,7 +179,9 @@ public class RoomWebService extends BaseWebService {
 			, @PathParam("type") @WebParam(name="type") String type
 			, @PathParam("externaltype") @WebParam(name="externaltype") String externalType
 			, @PathParam("externalid") @WebParam(name="externalid") String externalId
-			, @WebParam(name="room") @QueryParam("room") RoomDTO room) {
+			, @WebParam(name="room") @QueryParam("room") RoomDTO room
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Room r = roomDao.getExternal(Room.Type.valueOf(type), externalType, externalId);
 			if (r == null) {
@@ -197,11 +209,15 @@ public class RoomWebService extends BaseWebService {
 	 *            room object
 	 *
 	 * @return - id of the USER added or error code
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@POST
 	@Path("/")
-	public RoomDTO add(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="room") @FormParam("room") RoomDTO room) {
+	public RoomDTO add(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="room") @FormParam("room") RoomDTO room
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Room r = room.get(roomDao, groupDao, fileDao);
 			r = updateRtoRoom(r, sd.getUserId());
@@ -216,11 +232,15 @@ public class RoomWebService extends BaseWebService {
 	 * @param id - The id of the room
 	 *
 	 * @return - id of the room deleted
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@DELETE
 	@Path("/{id}")
-	public ServiceResult delete(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="id") @PathParam("id") long id) {
+	public ServiceResult delete(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="id") @PathParam("id") long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Room r = roomDao.get(id);
 			if (r == null) {
@@ -245,11 +265,15 @@ public class RoomWebService extends BaseWebService {
 	 *            the room id
 	 *
 	 * @return - 1 in case of success, -2 otherwise
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/close/{id}")
-	public ServiceResult close(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="id") @PathParam("id") long id) {
+	public ServiceResult close(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="id") @PathParam("id") long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Long userId = sd.getUserId();
 			Room room = roomDao.get(id);
@@ -276,11 +300,15 @@ public class RoomWebService extends BaseWebService {
 	 *            the room id
 	 *
 	 * @return - 1 in case of success, -2 otherwise
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/open/{id}")
-	public ServiceResult open(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="id") @PathParam("id") long id) {
+	public ServiceResult open(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="id") @PathParam("id") long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			Room room = roomDao.get(id);
 			room.setClosed(false);
@@ -299,11 +327,15 @@ public class RoomWebService extends BaseWebService {
 	 *            the room id
 	 *
 	 * @return - true if USER was kicked, false otherwise
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/kick/{id}")
-	public ServiceResult kickAll(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="id") @PathParam("id") long id) {
+	public ServiceResult kickAll(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="id") @PathParam("id") long id
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			boolean result = userManager.kickUsersByRoomId(id);
 			return new ServiceResult(result ? "Kicked" : "Not kicked", Type.SUCCESS);
@@ -323,6 +355,7 @@ public class RoomWebService extends BaseWebService {
 	 *            external id of USER to kick
 	 *
 	 * @return - true if USER was kicked, false otherwise
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
@@ -330,7 +363,8 @@ public class RoomWebService extends BaseWebService {
 	public ServiceResult kick(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="id") @PathParam("id") long id
 			, @WebParam(name="externalType") @PathParam("externalType") String externalType
-			, @WebParam(name="externalId") @PathParam("externalId") String externalId)
+			, @WebParam(name="externalId") @PathParam("externalId") String externalId
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			boolean result = userManager.kickExternal(id, externalType, externalId);
@@ -348,7 +382,10 @@ public class RoomWebService extends BaseWebService {
 	@WebMethod
 	@GET
 	@Path("/count/{roomid}")
-	public ServiceResult count(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="roomid") @PathParam("roomid") Long roomId) {
+	public ServiceResult count(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="roomid") @PathParam("roomid") Long roomId
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> new ServiceResult(String.valueOf(clientManager.streamByRoom(roomId).count()), Type.SUCCESS));
 	}
 
@@ -358,11 +395,15 @@ public class RoomWebService extends BaseWebService {
 	 * @param sid The SID from UserService.getSession
 	 * @param roomId id of the room to get users
 	 * @return {@link List} of users in the room
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/users/{roomid}")
-	public List<UserDTO> users(@WebParam(name="sid") @QueryParam("sid") String sid, @WebParam(name="roomid") @PathParam("roomid") Long roomId) {
+	public List<UserDTO> users(@WebParam(name="sid") @QueryParam("sid") String sid
+			, @WebParam(name="roomid") @PathParam("roomid") Long roomId
+			) throws ServiceException
+	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			return clientManager.streamByRoom(roomId)
 					.map(c -> new UserDTO(c.getUser()))
@@ -377,6 +418,7 @@ public class RoomWebService extends BaseWebService {
 	 * @param invite - parameters of the invitation
 	 * @param sendmail - flag to determine if email should be sent or not
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@POST
@@ -384,7 +426,7 @@ public class RoomWebService extends BaseWebService {
 	public ServiceResult hash(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="invite") @QueryParam("invite") InvitationDTO invite
 			, @WebParam(name="sendmail") @QueryParam("sendmail") boolean sendmail
-			)
+			) throws ServiceException
 	{
 		log.debug("[hash] invite {}", invite);
 		return performCall(sid, User.Right.SOAP, sd -> {
@@ -396,7 +438,7 @@ public class RoomWebService extends BaseWebService {
 					try {
 						inviteManager.sendInvitationLink(i, MessageType.CREATE, invite.getSubject(), invite.getMessage(), false, null);
 					} catch (Exception e) {
-						throw new ServiceException(e.getMessage());
+						throw new InternalServiceException(e.getMessage());
 					}
 				}
 				return new ServiceResult(i.getHash(), Type.SUCCESS);
@@ -414,6 +456,7 @@ public class RoomWebService extends BaseWebService {
 	 * @param sid - The SID of the User. This SID must be marked as Loggedin
 	 * @param id - id of the room to clean
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@Deprecated(since = "5.0.0-M3")
 	@WebMethod
@@ -421,7 +464,7 @@ public class RoomWebService extends BaseWebService {
 	@Path("/cleanwb/{id}")
 	public ServiceResult cleanWb(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="id") @PathParam("id") long id
-			)
+			) throws ServiceException
 	{
 		log.debug("[cleanwb] room id {}", id);
 		return performCall(sid, User.Right.SOAP, sd -> {

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/UserWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/UserWebService.java
@@ -156,7 +156,7 @@ public class UserWebService extends BaseWebService {
 			@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="user") @FormParam("user") UserDTO user
 			, @WebParam(name="confirm") @FormParam("confirm") Boolean confirm
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			if (!isAllowRegisterSoap()) {
@@ -180,7 +180,7 @@ public class UserWebService extends BaseWebService {
 				user.setLanguageId(1L);
 			}
 			User jsonUser = user.get(userDao, groupDao);
-			IValidator<String> passValidator = new StrongPasswordValidator(true, jsonUser);
+			IValidator<String> passValidator = new StrongPasswordValidator(false, jsonUser);
 			Validatable<String> passVal = new Validatable<>(user.getPassword());
 			passValidator.validate(passVal);
 			if (!passVal.isValid()) {
@@ -294,7 +294,7 @@ public class UserWebService extends BaseWebService {
 			@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="user") @FormParam("user") ExternalUserDTO user
 			, @WebParam(name="options") @FormParam("options") RoomOptionsDTO options
-			)
+			) throws ServiceException
 	{
 		return performCall(sid, User.Right.SOAP, sd -> {
 			if (Strings.isEmpty(user.getExternalId()) || Strings.isEmpty(user.getExternalType())) {

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/WbWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/WbWebService.java
@@ -52,6 +52,7 @@ import org.apache.openmeetings.db.entity.room.Room.RoomElement;
 import org.apache.openmeetings.db.entity.user.User;
 import org.apache.openmeetings.db.manager.IClientManager;
 import org.apache.openmeetings.db.manager.IWhiteboardManager;
+import org.apache.openmeetings.webservice.error.ServiceException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -90,13 +91,14 @@ public class WbWebService extends BaseWebService {
 	 * @param sid - The SID of the User. This SID must be marked as Loggedin
 	 * @param id - id of the room to clean
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
 	@Path("/resetwb/{id}")
 	public ServiceResult resetWb(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="id") @PathParam("id") long id
-			)
+			) throws ServiceException
 	{
 		log.debug("[resetWb] room id {}", id);
 		return performCall(sid, User.Right.SOAP, sd -> {
@@ -112,6 +114,7 @@ public class WbWebService extends BaseWebService {
 	 * @param roomId - id of the room to clean
 	 * @param wbId - id of the white board to clean
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
@@ -119,7 +122,7 @@ public class WbWebService extends BaseWebService {
 	public ServiceResult cleanWb(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="roomid") @PathParam("roomid") long roomId
 			, @WebParam(name="wbid") @PathParam("wbid") long wbId
-			)
+			) throws ServiceException
 	{
 		log.debug("[cleanWb] room id {}, wb id {}", roomId, wbId);
 		return performCall(sid, User.Right.SOAP, sd -> {
@@ -136,6 +139,7 @@ public class WbWebService extends BaseWebService {
 	 * @param wbId - id of the white board to clean
 	 * @param slide - slide number (zero based)
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@GET
@@ -144,7 +148,7 @@ public class WbWebService extends BaseWebService {
 			, @WebParam(name="roomid") @PathParam("roomid") long roomId
 			, @WebParam(name="wbid") @PathParam("wbid") long wbId
 			, @WebParam(name="slide") @PathParam("slide") int slide
-			)
+			) throws ServiceException
 	{
 		log.debug("[cleanSlide] room id {}, wb id {}, slide {}", roomId, wbId, slide);
 		return performCall(sid, User.Right.SOAP, sd -> {
@@ -163,6 +167,7 @@ public class WbWebService extends BaseWebService {
 	 * @param type - the type of document being saved PNG/PDF
 	 * @param data - binary data
 	 * @return - serviceResult object with the result
+	 * @throws {@link ServiceException} in case of any errors
 	 */
 	@WebMethod
 	@POST
@@ -170,7 +175,7 @@ public class WbWebService extends BaseWebService {
 	public ServiceResult uploadWb(@WebParam(name="sid") @QueryParam("sid") String sid
 			, @WebParam(name="type") @PathParam("type") String type
 			, @WebParam(name="data") @FormParam("data") String data
-			)
+			) throws ServiceException
 	{
 		log.debug("[uploadwb] type {}", type);
 		Client c = cm.getBySid(sid);

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/error/InternalServiceException.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/error/InternalServiceException.java
@@ -18,16 +18,10 @@
  */
 package org.apache.openmeetings.webservice.error;
 
-import javax.xml.ws.WebFault;
-
-import org.apache.openmeetings.db.dto.basic.ServiceResult;
-
-@WebFault
-public class ServiceException extends Exception {
+public class InternalServiceException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
-	public static final ServiceException NO_PERMISSION = new ServiceException(ServiceResult.NO_PERMISSION.getMessage());
 
-	public ServiceException(String msg) {
+	public InternalServiceException(String msg) {
 		super(msg);
 	}
 }

--- a/openmeetings-webservice/src/test/java/org/apache/openmeetings/webservice/TestBaseService.java
+++ b/openmeetings-webservice/src/test/java/org/apache/openmeetings/webservice/TestBaseService.java
@@ -20,28 +20,18 @@ package org.apache.openmeetings.webservice;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Set;
 
 import org.apache.openmeetings.db.entity.server.Sessiondata;
 import org.apache.openmeetings.db.entity.user.User.Right;
+import org.apache.openmeetings.webservice.error.InternalServiceException;
 import org.apache.openmeetings.webservice.error.ServiceException;
 import org.junit.jupiter.api.Test;
 
-import com.sun.star.uno.RuntimeException;
-
 class TestBaseService {
-	private static void checkException(Runnable r) {
-		try {
-			r.run();
-			fail("ServiceException expected");
-		} catch (ServiceException e) {
-			assertTrue(true, "expected");
-		}
-	}
-
 	@Test
 	void testCheck() {
 		Sessiondata sd = new BaseWebService() {}.check(null);
@@ -66,7 +56,9 @@ class TestBaseService {
 
 	@Test
 	void testPerformCall() {
-		checkException(() -> new BaseWebService() {}.performCall("", sd -> true
-				, sd -> { throw new RuntimeException("test"); }));
+		assertThrows(ServiceException.class, () -> {
+			new BaseWebService() {}.performCall("", sd -> true
+				, sd -> { throw new InternalServiceException("test"); });
+		});
 	}
 }


### PR DESCRIPTION
This will improve that the response will contain the actual error.

For Soap Responses it will work fine.

For Json it would be better to not only improve that it returns the actual error but also generates Json in the error response, instead of a HTML error page. So that you can parse the error in Json and actually use.