### PR TITLE
OPENMEETINGS-2577 performance  metrics disabled state

### DIFF
--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/StreamProcessorActions.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/StreamProcessorActions.java
@@ -1,0 +1,127 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openmeetings.core.remote;
+
+import static org.apache.openmeetings.core.remote.KurentoHandler.PARAM_CANDIDATE;
+import static org.apache.openmeetings.core.remote.KurentoHandler.sendError;
+
+import org.apache.openmeetings.core.util.WebSocketHelper;
+import org.apache.openmeetings.db.entity.basic.Client;
+import org.apache.openmeetings.db.entity.basic.Client.Activity;
+import org.apache.openmeetings.db.entity.basic.Client.StreamDesc;
+import org.apache.openmeetings.db.entity.basic.Client.StreamType;
+import org.apache.openmeetings.db.manager.IClientManager;
+import org.apache.openmeetings.util.logging.TimedApplication;
+import org.apache.wicket.util.string.Strings;
+import org.kurento.client.IceCandidate;
+import org.kurento.client.internal.server.KurentoServerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.github.openjson.JSONObject;
+
+@Component
+public class StreamProcessorActions {
+
+	private static final Logger log = LoggerFactory.getLogger(StreamProcessor.class);
+
+	@Autowired
+	private IClientManager cm;
+	@Autowired
+	private KurentoHandler kHandler;
+	@Autowired
+	private StreamProcessor streamProcessor;
+
+	@TimedApplication
+	protected void addIceCandidate(JSONObject msg) {
+		final String uid = msg.optString("uid");
+		KStream sender;
+		sender = streamProcessor.getByUid(uid);
+		if (sender != null) {
+			JSONObject candidate = msg.getJSONObject(PARAM_CANDIDATE);
+			String candStr = candidate.getString(PARAM_CANDIDATE);
+			if (!Strings.isEmpty(candStr)) {
+				IceCandidate cand = new IceCandidate(
+						candStr
+						, candidate.getString("sdpMid")
+						, candidate.getInt("sdpMLineIndex"));
+				sender.addCandidate(cand, msg.getString("luid"));
+			}
+		}
+	}
+
+	@TimedApplication
+	protected void addListener(Client c, JSONObject msg) {
+		KStream sender = streamProcessor.getByUid(msg.getString("sender"));
+		if (sender != null) {
+			Client sendClient = cm.getBySid(sender.getSid());
+			StreamDesc sd = sendClient.getStream(sender.getUid());
+			if (sd == null) {
+				return;
+			}
+			if (StreamType.SCREEN == sd.getType() && sd.hasActivity(Activity.RECORD) && !sd.hasActivity(Activity.SCREEN)) {
+				return;
+			}
+			sender.addListener(c.getSid(), c.getUid(), msg.getString("sdpOffer"));
+		}
+	}
+
+	@TimedApplication
+	protected void handleBroadcastRestarted(Client c, final String uid) {
+		if (!kHandler.isConnected()) {
+			return;
+		}
+		KStream sender = streamProcessor.getByUid(uid);
+		if (sender != null) {
+			sender.broadcastRestarted();
+		}
+	}
+
+	@TimedApplication
+	protected void handleBroadcastStarted(Client c, final String uid, JSONObject msg) {
+		if (!kHandler.isConnected()) {
+			return;
+		}
+		StreamDesc sd = c.getStream(uid);
+		KStream sender = streamProcessor.getByUid(uid);
+		try {
+			if (sender == null) {
+				KRoom room = kHandler.getRoom(c.getRoomId());
+				sender = room.join(sd, kHandler);
+			}
+			if (msg.has("width")) {
+				sd.setWidth(msg.getInt("width")).setHeight(msg.getInt("height"));
+				cm.update(c);
+			}
+			streamProcessor.startBroadcast(sender, sd, msg.getString("sdpOffer"), () -> {
+				if (StreamType.SCREEN == sd.getType() && sd.hasActivity(Activity.RECORD) && !streamProcessor.isRecording(c.getRoomId())) {
+					streamProcessor.startRecording(c);
+				}
+			});
+		} catch (KurentoServerException e) {
+			sender.release();
+			WebSocketHelper.sendClient(c, StreamProcessor.newStoppedMsg(sd));
+			sendError(c, "Failed to start broadcast: " + e.getMessage());
+			log.error("Failed to start broadcast", e);
+		}
+	}
+}

--- a/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
+++ b/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
@@ -61,6 +61,9 @@ public class BaseMockedTest {
 	protected RomManager romManager;
 	@Mock
 	protected ServerManager kServerManager;
+	@Spy
+	@InjectMocks
+	protected StreamProcessorActions streamProcessorActions;
 	@Mock
 	protected KurentoClient client;
 	@Spy

--- a/openmeetings-util/pom.xml
+++ b/openmeetings-util/pom.xml
@@ -133,5 +133,22 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-parsers</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjtools</artifactId>
+			<version>1.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/openmeetings-util/pom.xml
+++ b/openmeetings-util/pom.xml
@@ -144,7 +144,6 @@
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjtools</artifactId>
-			<version>1.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusAspect.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusAspect.java
@@ -1,0 +1,60 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openmeetings.util.logging;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import io.prometheus.client.Histogram;
+
+@Aspect
+@Component
+public class PrometheusAspect {
+
+	@Around("@annotation(TimedDatabase)")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+		String methodName = joinPoint.getSignature().getName();
+		Histogram.Timer timer = PrometheusUtil.getHistogram() //
+				.labels(className, methodName, "database", "default").startTimer();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			timer.observeDuration();
+		}
+	}
+
+	@Around("@annotation(TimedApplication)")
+	public Object logExecutionTimedApplication(ProceedingJoinPoint joinPoint) throws Throwable {
+		String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+		String methodName = joinPoint.getSignature().getName();
+		Histogram.Timer timer = PrometheusUtil.getHistogram() //
+				.labels(className, methodName, "application", "default").startTimer();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			timer.observeDuration();
+		}
+	}
+
+
+}

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusUtil.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusUtil.java
@@ -1,0 +1,16 @@
+package org.apache.openmeetings.util.logging;
+
+import io.prometheus.client.Histogram;
+
+public class PrometheusUtil {
+
+	private static Histogram histogram = Histogram.build() //
+			.help("OpenMeetings Application Metrics") //
+			.name("org_openmeetings_metrics") //
+			.labelNames("class", "method", "type", "message") //
+			.register();
+
+	public static Histogram getHistogram() {
+		return histogram;
+	}
+}

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusUtil.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/PrometheusUtil.java
@@ -1,3 +1,22 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.openmeetings.util.logging;
 
 import io.prometheus.client.Histogram;

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/TimedApplication.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/TimedApplication.java
@@ -1,0 +1,31 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openmeetings.util.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TimedApplication {
+
+}

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/TimedDatabase.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/logging/TimedDatabase.java
@@ -1,0 +1,31 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openmeetings.util.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TimedDatabase {
+
+}

--- a/openmeetings-web/pom.xml
+++ b/openmeetings-web/pom.xml
@@ -628,6 +628,14 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_servlet</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-catalina</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery-ui-touch-punch</artifactId>
 			<version>0.2.3-2</version>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/OpenMeetingsMetricsServlet.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/OpenMeetingsMetricsServlet.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openmeetings.web.util.logging;
+
+import io.prometheus.client.exporter.MetricsServlet;
+
+public class OpenMeetingsMetricsServlet extends MetricsServlet {
+
+	private static final long serialVersionUID = -2488393857088858502L;
+
+	public OpenMeetingsMetricsServlet() {
+		super();
+		new TomcatGenericExports(false).register();
+	}
+
+}

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
@@ -25,9 +25,18 @@ import org.apache.catalina.util.ServerInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.*;
 import java.lang.management.ManagementFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 
 /**
  * Exports Tomcat metrics applicable to most most applications:
@@ -63,7 +72,6 @@ import java.util.*;
  * tomcat_threads_active_max{pool="http-bio-0.0.0.0-8080",} 200.0
  * </pre>
  */
-
 public class TomcatGenericExports extends Collector {
 
 	private static final Logger log = LoggerFactory.getLogger(TomcatGenericExports.class);

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
@@ -1,0 +1,306 @@
+package org.apache.openmeetings.web.util.logging;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+import org.apache.catalina.util.ServerInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+import java.util.*;
+
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License") +  you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Exports Tomcat metrics applicable to most most applications:
+ *
+ * - http session metrics - request processor metrics - thread pool metrics
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * {@code
+ *   new TomcatGenericExports(false).register();
+ * }
+ * </pre>
+ *
+ * Example metrics being exported:
+ *
+ * <pre>
+ * tomcat_info{version="7.0.61.0",build="Apr 29 2015 14:58:03 UTC",} 1.0
+ * tomcat_session_active_total{context="/foo",host="default",} 877.0
+ * tomcat_session_rejected_total{context="/foo",host="default",} 0.0
+ * tomcat_session_created_total{context="/foo",host="default",} 24428.0
+ * tomcat_session_expired_total{context="/foo",host="default",} 23832.0
+ * tomcat_session_alivetime_seconds_avg{context="/foo",host="default",} 633.0
+ * tomcat_session_alivetime_seconds_max{context="/foo",host="default",} 9883.0
+ * tomcat_requestprocessor_received_bytes{name="http-bio-0.0.0.0-8080",} 0.0
+ * tomcat_requestprocessor_sent_bytes{name="http-bio-0.0.0.0-8080",} 5056098.0
+ * tomcat_requestprocessor_time_seconds{name="http-bio-0.0.0.0-8080",} 127386.0
+ * tomcat_requestprocessor_error_count{name="http-bio-0.0.0.0-8080",} 0.0
+ * tomcat_requestprocessor_request_count{name="http-bio-0.0.0.0-8080",} 33709.0
+ * tomcat_threads_total{pool="http-bio-0.0.0.0-8080",} 10.0
+ * tomcat_threads_active_total{pool="http-bio-0.0.0.0-8080",} 2.0
+ * tomcat_threads_active_max{pool="http-bio-0.0.0.0-8080",} 200.0
+ * </pre>
+ */
+
+public class TomcatGenericExports extends Collector {
+
+	private static final Logger log = LoggerFactory.getLogger(TomcatGenericExports.class);
+	private String jmxDomain = "Catalina";
+
+	public TomcatGenericExports(boolean embedded) {
+		if (embedded) {
+			jmxDomain = "Tomcat";
+		}
+	}
+
+	private void addRequestProcessorMetrics(List<MetricFamilySamples> mfs) {
+		try {
+			final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+			ObjectName filterName = new ObjectName(jmxDomain + ":type=GlobalRequestProcessor,name=*");
+			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
+
+			if (mBeans.size() > 0) {
+				List<String> labelNameList = Collections.singletonList("name");
+
+				GaugeMetricFamily requestProcessorBytesReceivedGauge = new GaugeMetricFamily(
+						"tomcat_requestprocessor_received_bytes", "Number of bytes received by this request processor",
+						labelNameList);
+
+				GaugeMetricFamily requestProcessorBytesSentGauge = new GaugeMetricFamily(
+						"tomcat_requestprocessor_sent_bytes", "Number of bytes sent by this request processor",
+						labelNameList);
+
+				GaugeMetricFamily requestProcessorProcessingTimeGauge = new GaugeMetricFamily(
+						"tomcat_requestprocessor_time_seconds", "The total time spend by this request processor",
+						labelNameList);
+
+				CounterMetricFamily requestProcessorErrorCounter = new CounterMetricFamily(
+						"tomcat_requestprocessor_error_count",
+						"The number of error request served by this request processor", labelNameList);
+
+				CounterMetricFamily requestProcessorRequestCounter = new CounterMetricFamily(
+						"tomcat_requestprocessor_request_count",
+						"The number of request served by this request processor", labelNameList);
+
+				for (final ObjectInstance mBean : mBeans) {
+					List<String> labelValueList = Collections
+							.singletonList(mBean.getObjectName().getKeyProperty("name").replaceAll("[\"\\\\]", ""));
+
+					requestProcessorBytesReceivedGauge.addMetric(labelValueList,
+							((Long) server.getAttribute(mBean.getObjectName(), "bytesReceived")).doubleValue());
+
+					requestProcessorBytesSentGauge.addMetric(labelValueList,
+							((Long) server.getAttribute(mBean.getObjectName(), "bytesSent")).doubleValue());
+
+					requestProcessorProcessingTimeGauge.addMetric(labelValueList,
+							((Long) server.getAttribute(mBean.getObjectName(), "processingTime")).doubleValue()
+									/ 1000.0);
+
+					requestProcessorErrorCounter.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "errorCount")).doubleValue());
+
+					requestProcessorRequestCounter.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "requestCount")).doubleValue());
+				}
+
+				mfs.add(requestProcessorBytesReceivedGauge);
+				mfs.add(requestProcessorBytesSentGauge);
+				mfs.add(requestProcessorProcessingTimeGauge);
+				mfs.add(requestProcessorRequestCounter);
+				mfs.add(requestProcessorErrorCounter);
+			}
+		} catch (Exception e) {
+			log.error("Error retrieving metric.", e);
+		}
+	}
+
+	private void addSessionMetrics(List<MetricFamilySamples> mfs) {
+		try {
+			final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+			ObjectName filterName = new ObjectName(jmxDomain + ":type=Manager,context=*,host=*");
+			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
+
+			if (mBeans.size() > 0) {
+				List<String> labelNameList = Arrays.asList("host", "context");
+
+				GaugeMetricFamily activeSessionCountGauge = new GaugeMetricFamily("tomcat_session_active_total",
+						"Number of active sessions", labelNameList);
+
+				GaugeMetricFamily rejectedSessionCountGauge = new GaugeMetricFamily("tomcat_session_rejected_total",
+						"Number of sessions rejected due to maxActive being reached", labelNameList);
+
+				GaugeMetricFamily createdSessionCountGauge = new GaugeMetricFamily("tomcat_session_created_total",
+						"Number of sessions created", labelNameList);
+
+				GaugeMetricFamily expiredSessionCountGauge = new GaugeMetricFamily("tomcat_session_expired_total",
+						"Number of sessions that expired", labelNameList);
+
+				GaugeMetricFamily sessionAvgAliveTimeGauge = new GaugeMetricFamily(
+						"tomcat_session_alivetime_seconds_avg", "Average time an expired session had been alive",
+						labelNameList);
+
+				GaugeMetricFamily sessionMaxAliveTimeGauge = new GaugeMetricFamily(
+						"tomcat_session_alivetime_seconds_max", "Maximum time an expired session had been alive",
+						labelNameList);
+
+				GaugeMetricFamily contextStateGauge = new GaugeMetricFamily("tomcat_context_state_started",
+						"Indication if the lifecycle state of this context is STARTED", labelNameList);
+
+				for (final ObjectInstance mBean : mBeans) {
+					List<String> labelValueList = Arrays.asList(mBean.getObjectName().getKeyProperty("host"),
+							mBean.getObjectName().getKeyProperty("context"));
+
+					activeSessionCountGauge.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "activeSessions")).doubleValue());
+
+					rejectedSessionCountGauge.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "rejectedSessions")).doubleValue());
+
+					createdSessionCountGauge.addMetric(labelValueList,
+							((Long) server.getAttribute(mBean.getObjectName(), "sessionCounter")).doubleValue());
+
+					expiredSessionCountGauge.addMetric(labelValueList,
+							((Long) server.getAttribute(mBean.getObjectName(), "expiredSessions")).doubleValue());
+
+					sessionAvgAliveTimeGauge.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "sessionAverageAliveTime"))
+									.doubleValue());
+
+					sessionMaxAliveTimeGauge.addMetric(labelValueList,
+							((Integer) server.getAttribute(mBean.getObjectName(), "sessionMaxAliveTime"))
+									.doubleValue());
+
+					if (server.getAttribute(mBean.getObjectName(), "stateName").equals("STARTED")) {
+						contextStateGauge.addMetric(labelValueList, 1.0);
+					} else {
+						contextStateGauge.addMetric(labelValueList, 0.0);
+					}
+				}
+
+				mfs.add(activeSessionCountGauge);
+				mfs.add(rejectedSessionCountGauge);
+				mfs.add(createdSessionCountGauge);
+				mfs.add(expiredSessionCountGauge);
+				mfs.add(sessionAvgAliveTimeGauge);
+				mfs.add(sessionMaxAliveTimeGauge);
+				mfs.add(contextStateGauge);
+			}
+		} catch (Exception e) {
+			log.error("Error retrieving metric.", e);
+		}
+	}
+
+	private void addThreadPoolMetrics(List<MetricFamilySamples> mfs) {
+		try {
+			final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+			ObjectName filterName = new ObjectName(jmxDomain + ":type=ThreadPool,name=*");
+			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
+
+			if (mBeans.size() > 0) {
+				List<String> labelList = Collections.singletonList("name");
+
+				GaugeMetricFamily threadPoolCurrentCountGauge = new GaugeMetricFamily("tomcat_threads_total",
+						"Number threads in this pool.", labelList);
+
+				GaugeMetricFamily threadPoolActiveCountGauge = new GaugeMetricFamily("tomcat_threads_active_total",
+						"Number of active threads in this pool.", labelList);
+
+				GaugeMetricFamily threadPoolMaxThreadsGauge = new GaugeMetricFamily("tomcat_threads_max",
+						"Maximum number of threads allowed in this pool.", labelList);
+
+				GaugeMetricFamily threadPoolConnectionCountGauge = new GaugeMetricFamily(
+						"tomcat_connections_active_total", "Number of connections served by this pool.", labelList);
+
+				GaugeMetricFamily threadPoolMaxConnectionGauge = new GaugeMetricFamily("tomcat_connections_active_max",
+						"Maximum number of concurrent connections served by this pool.", labelList);
+
+				String[] genericAttributes = new String[] { "currentThreadCount", "currentThreadsBusy", "maxThreads",
+						"connectionCount", "maxConnections" };
+
+				for (final ObjectInstance mBean : mBeans) {
+					List<String> labelValueList = Collections
+							.singletonList(mBean.getObjectName().getKeyProperty("name").replaceAll("[\"\\\\]", ""));
+					AttributeList attributeList = server.getAttributes(mBean.getObjectName(), genericAttributes);
+					for (Attribute attribute : attributeList.asList()) {
+						switch (attribute.getName()) {
+						case "currentThreadCount":
+							threadPoolCurrentCountGauge.addMetric(labelValueList,
+									((Integer) attribute.getValue()).doubleValue());
+							break;
+						case "currentThreadsBusy":
+							threadPoolActiveCountGauge.addMetric(labelValueList,
+									((Integer) attribute.getValue()).doubleValue());
+							break;
+						case "maxThreads":
+							threadPoolMaxThreadsGauge.addMetric(labelValueList,
+									((Integer) attribute.getValue()).doubleValue());
+							break;
+						case "connectionCount":
+							threadPoolConnectionCountGauge.addMetric(labelValueList,
+									((Long) attribute.getValue()).doubleValue());
+							break;
+						case "maxConnections":
+							threadPoolMaxConnectionGauge.addMetric(labelValueList,
+									((Integer) attribute.getValue()).doubleValue());
+
+						}
+					}
+				}
+
+				addNonEmptyMetricFamily(mfs, threadPoolCurrentCountGauge);
+				addNonEmptyMetricFamily(mfs, threadPoolActiveCountGauge);
+				addNonEmptyMetricFamily(mfs, threadPoolMaxThreadsGauge);
+				addNonEmptyMetricFamily(mfs, threadPoolConnectionCountGauge);
+				addNonEmptyMetricFamily(mfs, threadPoolMaxConnectionGauge);
+			}
+		} catch (Exception e) {
+			log.error("Error retrieving metric:" + e.getMessage());
+		}
+	}
+
+	private void addVersionInfo(List<MetricFamilySamples> mfs) {
+		GaugeMetricFamily tomcatInfo = new GaugeMetricFamily("tomcat_info", "tomcat version info",
+				Arrays.asList("version", "build"));
+		tomcatInfo.addMetric(Arrays.asList(ServerInfo.getServerNumber(), ServerInfo.getServerBuilt()), 1);
+		mfs.add(tomcatInfo);
+	}
+
+	private void addNonEmptyMetricFamily(List<MetricFamilySamples> mfs, GaugeMetricFamily metricFamily) {
+		if (metricFamily.samples.size() > 0) {
+			mfs.add(metricFamily);
+		}
+	}
+
+	public List<MetricFamilySamples> collect() {
+		List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+		addSessionMetrics(mfs);
+		addThreadPoolMetrics(mfs);
+		addRequestProcessorMetrics(mfs);
+		addVersionInfo(mfs);
+		return mfs;
+
+	}
+}

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
@@ -76,6 +76,7 @@ public class TomcatGenericExports extends Collector {
 
 	private static final Logger log = LoggerFactory.getLogger(TomcatGenericExports.class);
 	private String jmxDomain = "Catalina";
+	private final String labelName = "name";
 
 	public TomcatGenericExports(boolean embedded) {
 		if (embedded) {
@@ -90,7 +91,7 @@ public class TomcatGenericExports extends Collector {
 			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
 
 			if (mBeans.size() > 0) {
-				List<String> labelNameList = Collections.singletonList("name");
+				List<String> labelNameList = List.of(labelName);
 
 				GaugeMetricFamily requestProcessorBytesReceivedGauge = new GaugeMetricFamily(
 						"tomcat_requestprocessor_received_bytes", "Number of bytes received by this request processor",
@@ -151,7 +152,7 @@ public class TomcatGenericExports extends Collector {
 			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
 
 			if (mBeans.size() > 0) {
-				List<String> labelNameList = Arrays.asList("host", "context");
+				List<String> labelNameList = List.of("host", "context");
 
 				GaugeMetricFamily activeSessionCountGauge = new GaugeMetricFamily("tomcat_session_active_total",
 						"Number of active sessions", labelNameList);
@@ -227,7 +228,7 @@ public class TomcatGenericExports extends Collector {
 			Set<ObjectInstance> mBeans = server.queryMBeans(filterName, null);
 
 			if (mBeans.size() > 0) {
-				List<String> labelList = Collections.singletonList("name");
+				List<String> labelList = List.of(labelName);
 
 				GaugeMetricFamily threadPoolCurrentCountGauge = new GaugeMetricFamily("tomcat_threads_total",
 						"Number threads in this pool.", labelList);

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/util/logging/TomcatGenericExports.java
@@ -1,18 +1,4 @@
-package org.apache.openmeetings.web.util.logging;
-
-import io.prometheus.client.Collector;
-import io.prometheus.client.CounterMetricFamily;
-import io.prometheus.client.GaugeMetricFamily;
-import org.apache.catalina.util.ServerInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.management.*;
-import java.lang.management.ManagementFactory;
-import java.util.*;
-
 /*
-
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -30,6 +16,19 @@ import java.util.*;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.openmeetings.web.util.logging;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+import org.apache.catalina.util.ServerInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+import java.util.*;
+
 /**
  * Exports Tomcat metrics applicable to most most applications:
  *

--- a/openmeetings-web/src/main/webapp/WEB-INF/classes/applicationContext.xml
+++ b/openmeetings-web/src/main/webapp/WEB-INF/classes/applicationContext.xml
@@ -22,10 +22,12 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:tx="http://www.springframework.org/schema/tx"
 		xmlns:context="http://www.springframework.org/schema/context"
+		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:p="http://www.springframework.org/schema/p"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+			http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 			http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd"
 	>
 	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalEntityManagerFactoryBean">
@@ -38,6 +40,7 @@
 
 	<tx:annotation-driven transaction-manager="transactionManager" proxy-target-class="true" />
 	<context:annotation-config />
+	<aop:aspectj-autoproxy/>
 	<context:component-scan base-package="org.apache.openmeetings" />
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/openmeetings-web/src/main/webapp/WEB-INF/classes/applicationContext.xml
+++ b/openmeetings-web/src/main/webapp/WEB-INF/classes/applicationContext.xml
@@ -40,7 +40,9 @@
 
 	<tx:annotation-driven transaction-manager="transactionManager" proxy-target-class="true" />
 	<context:annotation-config />
+	<!-- Start annotation Prometheus metrics
 	<aop:aspectj-autoproxy/>
+	End annotation -->
 	<context:component-scan base-package="org.apache.openmeetings" />
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/openmeetings-web/src/main/webapp/WEB-INF/web.xml
+++ b/openmeetings-web/src/main/webapp/WEB-INF/web.xml
@@ -55,6 +55,7 @@
 		</init-param>
 	</filter>
 
+	<!-- Start Prometheus Filter HTTP Servlet metrics
 	<filter>
 		<filter-name>prometheusFilter</filter-name>
 		<filter-class>io.prometheus.client.filter.MetricsFilter</filter-class>
@@ -70,8 +71,6 @@
 			<param-name>buckets</param-name>
 			<param-value>0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10</param-value>
 		</init-param>
-		<!-- Optionally override path components; anything less than 1 (1 is the 
-			default) means full granularity -->
 		<init-param>
 			<param-name>path-components</param-name>
 			<param-value>0</param-value>
@@ -82,6 +81,7 @@
 		<filter-name>prometheusFilter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
+	End Prometheus -->
 	
 	<filter-mapping>
 		<filter-name>OpenmeetingsApplication</filter-name>
@@ -107,6 +107,7 @@
 		<url-pattern>/services/*</url-pattern>
 	</servlet-mapping>
 
+	<!-- Start Prometheus export metrics HTTP
 	<servlet>
 		<servlet-name>metrics</servlet-name>
 		<servlet-class>org.apache.openmeetings.web.util.logging.OpenMeetingsMetricsServlet</servlet-class>
@@ -115,6 +116,7 @@
 		<servlet-name>metrics</servlet-name>
 		<url-pattern>/services/metrics/</url-pattern>
 	</servlet-mapping>
+	End Prometheus -->
 
 	<mime-mapping>
 		<extension>inc</extension>

--- a/openmeetings-web/src/main/webapp/WEB-INF/web.xml
+++ b/openmeetings-web/src/main/webapp/WEB-INF/web.xml
@@ -54,6 +54,35 @@
 			<param-value>css,docs,images,js,persistence,public,screenshare,data,services</param-value>
 		</init-param>
 	</filter>
+
+	<filter>
+		<filter-name>prometheusFilter</filter-name>
+		<filter-class>io.prometheus.client.filter.MetricsFilter</filter-class>
+		<init-param>
+			<param-name>metric-name</param-name>
+			<param-value>webapp_metrics_filter</param-value>
+		</init-param>
+		<init-param>
+			<param-name>help</param-name>
+			<param-value>This is the help for your metrics filter</param-value>
+		</init-param>
+		<init-param>
+			<param-name>buckets</param-name>
+			<param-value>0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10</param-value>
+		</init-param>
+		<!-- Optionally override path components; anything less than 1 (1 is the 
+			default) means full granularity -->
+		<init-param>
+			<param-name>path-components</param-name>
+			<param-value>0</param-value>
+		</init-param>
+	</filter>
+
+	<filter-mapping>
+		<filter-name>prometheusFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+	
 	<filter-mapping>
 		<filter-name>OpenmeetingsApplication</filter-name>
 		<url-pattern>/*</url-pattern>
@@ -76,6 +105,15 @@
 	<servlet-mapping>
 		<servlet-name>CXFServlet</servlet-name>
 		<url-pattern>/services/*</url-pattern>
+	</servlet-mapping>
+
+	<servlet>
+		<servlet-name>metrics</servlet-name>
+		<servlet-class>io.prometheus.client.exporter.MetricsServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>metrics</servlet-name>
+		<url-pattern>/services/metrics/</url-pattern>
 	</servlet-mapping>
 
 	<mime-mapping>

--- a/openmeetings-web/src/main/webapp/WEB-INF/web.xml
+++ b/openmeetings-web/src/main/webapp/WEB-INF/web.xml
@@ -109,7 +109,7 @@
 
 	<servlet>
 		<servlet-name>metrics</servlet-name>
-		<servlet-class>io.prometheus.client.exporter.MetricsServlet</servlet-class>
+		<servlet-class>org.apache.openmeetings.web.util.logging.OpenMeetingsMetricsServlet</servlet-class>
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>metrics</servlet-name>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 		<tomcat.version>9.0.43</tomcat.version>
 		<ical4j.version>3.0.18</ical4j.version>
 		<cxf.version>3.4.2</cxf.version>
+		<io.prometheus.version>0.10.0</io.prometheus.version>
 		<simple-xml.version>2.7.1</simple-xml.version>
 		<jettison.version>1.4.1</jettison.version>
 		<site.basedir>${project.basedir}</site.basedir>
@@ -456,6 +457,17 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
+				<artifactId>spring-context</artifactId>
+				<version>${spring.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
 				<artifactId>spring-context-support</artifactId>
 				<version>${spring.version}</version>
 				<exclusions>
@@ -468,6 +480,17 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-orm</artifactId>
+				<version>${spring.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-aop</artifactId>
 				<version>${spring.version}</version>
 				<exclusions>
 					<exclusion>
@@ -534,6 +557,16 @@
 				<groupId>org.apache.cxf</groupId>
 				<artifactId>cxf-rt-features-logging</artifactId>
 				<version>${cxf.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.prometheus</groupId>
+				<artifactId>simpleclient</artifactId>
+				<version>${io.prometheus.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.prometheus</groupId>
+				<artifactId>simpleclient_servlet</artifactId>
+				<version>${io.prometheus.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.jettison</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,11 @@
 				<version>${io.prometheus.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.tomcat</groupId>
+				<artifactId>tomcat-catalina</artifactId>
+				<version>${tomcat.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.codehaus.jettison</groupId>
 				<artifactId>jettison</artifactId>
 				<version>${jettison.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 		<ical4j.version>3.0.18</ical4j.version>
 		<cxf.version>3.4.2</cxf.version>
 		<io.prometheus.version>0.10.0</io.prometheus.version>
+		<aspectjtools.version>1.9.6</aspectjtools.version>
 		<simple-xml.version>2.7.1</simple-xml.version>
 		<jettison.version>1.4.1</jettison.version>
 		<site.basedir>${project.basedir}</site.basedir>
@@ -567,6 +568,11 @@
 				<groupId>io.prometheus</groupId>
 				<artifactId>simpleclient_servlet</artifactId>
 				<version>${io.prometheus.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.aspectj</groupId>
+				<artifactId>aspectjtools</artifactId>
+				<version>${aspectjtools.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
As discussed:https://markmail.org/thread/new2mdd6jbyp2o6i

https://issues.apache.org/jira/browse/OPENMEETINGS-2577 Enables metrics - but in disabled state by default.

By default all gathering of metrics as well as exposing metrics is disabled!

In order to enable it there needs to be configuration in the web.xml and applicationContext.xml updated.

See documentation on how to enable it:
https://cwiki.apache.org/confluence/display/OPENMEETINGS/Prometheus+Logging+and+Metrics#PrometheusLoggingandMetrics-EnableMetrics

