### PR TITLE
OPENMEETINGS-2580 Enable additional logs for making failed attempts to add ice candidate visible

### DIFF
--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
@@ -504,9 +504,10 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 		sipProcessor = Optional.empty();
 	}
 
-	public void addCandidate(IceCandidate candidate, String uid) {
+	public void addIceCandidate(IceCandidate candidate, String uid) {
 		if (this.uid.equals(uid)) {
 			if (!(outgoingMedia instanceof WebRtcEndpoint)) {
+				log.warn("addIceCandidate iceCandidate while not ready yet, uid: {}", uid);
 				return;
 			}
 			((WebRtcEndpoint)outgoingMedia).addIceCandidate(candidate);
@@ -515,6 +516,8 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 			log.debug("Add candidate for {}, listener found ? {}", uid, endpoint != null);
 			if (endpoint != null) {
 				endpoint.addIceCandidate(candidate);
+			} else {
+				log.warn("addIceCandidate iceCandidate could not find endpoint, uid: {}", uid);
 			}
 		}
 	}

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
@@ -32,15 +32,14 @@ import static org.apache.openmeetings.core.remote.KurentoHandler.newKurentoMsg;
 import static org.apache.openmeetings.util.OmFileHelper.getRecUri;
 import static org.apache.openmeetings.util.OmFileHelper.getRecordingChunk;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -84,10 +83,10 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 	private MediaPipeline pipeline;
 	private RecorderEndpoint recorder;
 	private BaseRtpEndpoint outgoingMedia = null;
-	private List<IceCandidate> candidatesQueue = new ArrayList<>();
+	private Queue<IceCandidate> candidatesQueue = new ConcurrentLinkedQueue<>();
 	private RtpEndpoint rtpEndpoint;
 	private Optional<SipStackProcessor> sipProcessor = Optional.empty();
-	private final ConcurrentMap<String, WebRtcEndpoint> listeners = new ConcurrentHashMap<>();
+	private final Map<String, WebRtcEndpoint> listeners = new ConcurrentHashMap<>();
 	private Optional<CompletableFuture<Object>> flowoutFuture = Optional.empty();
 	private ListenerSubscription flowoutSubscription;
 	private Long chunkId;
@@ -152,7 +151,7 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 					addSipProcessor(1);
 				} else {
 					outgoingMedia = createEndpoint(sd.getSid(), sd.getUid(), true);
-					if (candidatesQueue.size() > 0) {
+					if (!candidatesQueue.isEmpty()) {
 						log.trace("addIceCandidate iceCandidate reply from not ready, uid: {}", sd.getUid());
 						candidatesQueue.stream()
 							.forEach(candidate -> ((WebRtcEndpoint)outgoingMedia).addIceCandidate(candidate));
@@ -516,8 +515,10 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 	public void addIceCandidate(IceCandidate candidate, String uid) {
 		if (this.uid.equals(uid)) {
 			if (!(outgoingMedia instanceof WebRtcEndpoint)) {
-				log.info("addIceCandidate iceCandidate while not ready yet, uid: {}", uid);
-				candidatesQueue.add(candidate);
+				if (!sipClient) {
+					log.info("addIceCandidate iceCandidate while not ready yet, uid: {}", uid);
+					candidatesQueue.add(candidate);
+				}
 				return;
 			}
 			((WebRtcEndpoint)outgoingMedia).addIceCandidate(candidate);

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/StreamProcessorActions.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/StreamProcessorActions.java
@@ -54,17 +54,19 @@ public class StreamProcessorActions {
 	protected void addIceCandidate(JSONObject msg) {
 		final String uid = msg.optString("uid");
 		KStream sender;
+		JSONObject candidate = msg.getJSONObject(PARAM_CANDIDATE);
+		String candStr = candidate.getString(PARAM_CANDIDATE);
 		sender = streamProcessor.getByUid(uid);
 		if (sender != null) {
-			JSONObject candidate = msg.getJSONObject(PARAM_CANDIDATE);
-			String candStr = candidate.getString(PARAM_CANDIDATE);
 			if (!Strings.isEmpty(candStr)) {
 				IceCandidate cand = new IceCandidate(
 						candStr
 						, candidate.getString("sdpMid")
 						, candidate.getInt("sdpMLineIndex"));
-				sender.addCandidate(cand, msg.getString("luid"));
+				sender.addIceCandidate(cand, msg.getString("luid"));
 			}
+		} else {
+			log.warn("addIceCandidate sender is empty, uid: {}, candStr: {} ", uid, candStr);
 		}
 	}
 


### PR DESCRIPTION
Just adding logging for now to make missed iceCandidates visible + adding queue as discussed in mailing list according to Kurento examples.

Tbd further via mailing list: https://markmail.org/thread/eadssnmeo255dsll
