### PR TITLE
OPENMEETINGS-2601 Able to configure which certificate type to use for WebRtcEndpoint

### DIFF
--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/AbstractStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/AbstractStream.java
@@ -18,6 +18,7 @@
  */
 package org.apache.openmeetings.core.remote;
 
+import org.kurento.client.CertificateKeyType;
 import org.kurento.client.MediaPipeline;
 import org.kurento.client.MediaProfileSpecType;
 import org.kurento.client.PlayerEndpoint;
@@ -48,8 +49,15 @@ public abstract class AbstractStream {
 
 	public abstract void release(boolean remove);
 
-	public static WebRtcEndpoint createWebRtcEndpoint(MediaPipeline pipeline, Boolean recv) {
+	public static WebRtcEndpoint createWebRtcEndpoint(MediaPipeline pipeline, Boolean recv,
+			String certificateType) {
 		WebRtcEndpoint.Builder builder = new WebRtcEndpoint.Builder(pipeline);
+		// See https://doc-kurento.readthedocs.io/en/latest/features/security.html#media-plane-security-dtls
+		if (CertificateKeyType.RSA.name().equals(certificateType)) {
+			builder.withCertificateKeyType(CertificateKeyType.RSA);
+		} else if (CertificateKeyType.ECDSA.name().equals(certificateType)) {
+			builder.withCertificateKeyType(CertificateKeyType.ECDSA);
+		}
 		if (recv != null) {
 			if (recv) {
 				builder.recvonly();

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/AbstractStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/AbstractStream.java
@@ -50,12 +50,12 @@ public abstract class AbstractStream {
 	public abstract void release(boolean remove);
 
 	public static WebRtcEndpoint createWebRtcEndpoint(MediaPipeline pipeline, Boolean recv,
-			String certificateType) {
+			CertificateKeyType certificateType) {
 		WebRtcEndpoint.Builder builder = new WebRtcEndpoint.Builder(pipeline);
 		// See https://doc-kurento.readthedocs.io/en/latest/features/security.html#media-plane-security-dtls
-		if (CertificateKeyType.RSA.name().equals(certificateType)) {
+		if (CertificateKeyType.RSA == certificateType) {
 			builder.withCertificateKeyType(CertificateKeyType.RSA);
-		} else if (CertificateKeyType.ECDSA.name().equals(certificateType)) {
+		} else if (CertificateKeyType.ECDSA == certificateType) {
 			builder.withCertificateKeyType(CertificateKeyType.ECDSA);
 		}
 		if (recv != null) {

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KStream.java
@@ -319,7 +319,7 @@ public class KStream extends AbstractStream implements ISipCallbacks {
 	}
 
 	private WebRtcEndpoint createEndpoint(String sid, String uid, boolean recv) {
-		WebRtcEndpoint endpoint = createWebRtcEndpoint(pipeline, recv);
+		WebRtcEndpoint endpoint = createWebRtcEndpoint(pipeline, recv, kHandler.getCertificateType());
 		setTags(endpoint, uid);
 		reApplyIceCandiates(endpoint, recv);
 

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KTestStream.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KTestStream.java
@@ -80,7 +80,7 @@ public class KTestStream extends AbstractStream {
 	}
 
 	private void startTestRecording(IWsClient c, JSONObject msg) {
-		webRtcEndpoint = createWebRtcEndpoint(pipeline, null);
+		webRtcEndpoint = createWebRtcEndpoint(pipeline, null, kHandler.getCertificateType());
 		webRtcEndpoint.connect(webRtcEndpoint);
 
 		MediaProfileSpecType profile = getProfile(msg);
@@ -142,7 +142,7 @@ public class KTestStream extends AbstractStream {
 
 	public void play(final IWsClient inClient, JSONObject msg) {
 		createPipeline(() -> {
-			webRtcEndpoint = createWebRtcEndpoint(pipeline, true);
+			webRtcEndpoint = createWebRtcEndpoint(pipeline, true, kHandler.getCertificateType());
 			player = createPlayerEndpoint(pipeline, recPath);
 			player.connect(webRtcEndpoint);
 			webRtcEndpoint.addMediaSessionStartedListener(evt -> {

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KurentoHandler.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KurentoHandler.java
@@ -54,6 +54,7 @@ import org.apache.openmeetings.db.manager.IClientManager;
 import org.apache.openmeetings.db.util.ws.RoomMessage;
 import org.apache.openmeetings.db.util.ws.TextRoomMessage;
 import org.apache.wicket.util.string.Strings;
+import org.kurento.client.CertificateKeyType;
 import org.kurento.client.Continuation;
 import org.kurento.client.Endpoint;
 import org.kurento.client.EventListener;
@@ -112,8 +113,7 @@ public class KurentoHandler {
 	private int watchThreadCount = 10;
 	@Value("${kurento.kuid}")
 	private String kuid;
-	@Value("${kurento.certificateType}")
-	private String certificateType;
+	private CertificateKeyType certificateType;
 	private KurentoClient client;
 	private final AtomicBoolean connected = new AtomicBoolean(false);
 	private final Map<Long, KRoom> rooms = new ConcurrentHashMap<>();
@@ -393,7 +393,15 @@ public class KurentoHandler {
 		return kuid;
 	}
 
-	public String getCertificateType() {
+	@Value("${kurento.certificateType}")
+	public void setCertificateType(String certificateType) {
+		if (certificateType.isEmpty()) {
+			return;
+		}
+		this.certificateType = CertificateKeyType.valueOf(certificateType);
+	}
+
+	public CertificateKeyType getCertificateType() {
 		return certificateType;
 	}
 

--- a/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KurentoHandler.java
+++ b/openmeetings-core/src/main/java/org/apache/openmeetings/core/remote/KurentoHandler.java
@@ -112,6 +112,8 @@ public class KurentoHandler {
 	private int watchThreadCount = 10;
 	@Value("${kurento.kuid}")
 	private String kuid;
+	@Value("${kurento.certificateType}")
+	private String certificateType;
 	private KurentoClient client;
 	private final AtomicBoolean connected = new AtomicBoolean(false);
 	private final Map<Long, KRoom> rooms = new ConcurrentHashMap<>();
@@ -389,6 +391,10 @@ public class KurentoHandler {
 
 	String getKuid() {
 		return kuid;
+	}
+
+	public String getCertificateType() {
+		return certificateType;
 	}
 
 	static int getFlowoutTimeout() {

--- a/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
+++ b/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
@@ -114,7 +114,7 @@ public class BaseMockedTest {
 					return null;
 				}
 			});
-			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean(), null)).thenReturn(mock(WebRtcEndpoint.class));
+			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean(), any())).thenReturn(mock(WebRtcEndpoint.class));
 			streamMock.when(() -> AbstractStream.createRecorderEndpoint(any(MediaPipeline.class), anyString(), any(MediaProfileSpecType.class))).thenReturn(mock(RecorderEndpoint.class));
 			streamMock.when(() -> AbstractStream.createPlayerEndpoint(any(MediaPipeline.class), anyString())).thenReturn(mock(PlayerEndpoint.class));
 

--- a/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
+++ b/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
@@ -114,7 +114,7 @@ public class BaseMockedTest {
 					return null;
 				}
 			});
-			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean(), anyString())).thenReturn(mock(WebRtcEndpoint.class));
+			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean(), null)).thenReturn(mock(WebRtcEndpoint.class));
 			streamMock.when(() -> AbstractStream.createRecorderEndpoint(any(MediaPipeline.class), anyString(), any(MediaProfileSpecType.class))).thenReturn(mock(RecorderEndpoint.class));
 			streamMock.when(() -> AbstractStream.createPlayerEndpoint(any(MediaPipeline.class), anyString())).thenReturn(mock(PlayerEndpoint.class));
 

--- a/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
+++ b/openmeetings-core/src/test/java/org/apache/openmeetings/core/remote/BaseMockedTest.java
@@ -114,7 +114,7 @@ public class BaseMockedTest {
 					return null;
 				}
 			});
-			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean())).thenReturn(mock(WebRtcEndpoint.class));
+			streamMock.when(() -> AbstractStream.createWebRtcEndpoint(any(MediaPipeline.class), anyBoolean(), anyString())).thenReturn(mock(WebRtcEndpoint.class));
 			streamMock.when(() -> AbstractStream.createRecorderEndpoint(any(MediaPipeline.class), anyString(), any(MediaProfileSpecType.class))).thenReturn(mock(RecorderEndpoint.class));
 			streamMock.when(() -> AbstractStream.createPlayerEndpoint(any(MediaPipeline.class), anyString())).thenReturn(mock(PlayerEndpoint.class));
 

--- a/openmeetings-web/src/main/webapp/WEB-INF/classes/openmeetings.properties
+++ b/openmeetings-web/src/main/webapp/WEB-INF/classes/openmeetings.properties
@@ -51,6 +51,9 @@ kurento.flowout.timeout=5
 kurento.kuid=df992960-e7b0-11ea-9acd-337fb30dd93d
 ## this list can be space and/or comma separated
 kurento.ignored.kuids=
+## See https://doc-kurento.readthedocs.io/en/latest/features/security.html#media-plane-security-dtls
+## possible values: RSA, or ECDSA (capital-case)
+kurento.certificateType=
 
 ################## NetTest ##################
 nettest.max.clients=50


### PR DESCRIPTION
See Jira at https://issues.apache.org/jira/browse/OPENMEETINGS-2601

This config is required in KMS and also when initialising the WebRtcEndpoint via the constructor. Just doing KMS config, will have no effect.