### PR TITLE
OPENMEETINGS-2654 Update website with new commands for updating JS code dynamically

### DIFF
--- a/openmeetings-server/src/site/xdoc/BuildInstructions.xml
+++ b/openmeetings-server/src/site/xdoc/BuildInstructions.xml
@@ -92,11 +92,22 @@ mvn install -P allModules,quick,mysql -pl openmeetings-util,openmeetings-db,open
 		<section name="Update JavaScript and CSS at runtime">
 			<div>
 				<p>You can update Javascript and CSS files and then copy them at runtime. No need to re-run the entire Server build and restart. This can greatly save time when developing:</p>
-				<source>mvn minify:minify@room-js minify:minify@interview-wb-js minify:minify@wb-js minify:minify@fileinput-js minify:minify@settings-js minify:minify@nettest-js minify:minify@chat-js minify:minify@theme-minify</source>
-				<p>You can further trim down the compile time to just selected Javascript sections:</p>
-				<source>mvn minify:minify@room-js minify:minify@interview-wb-js</source>
-				<p>And then copy them into the relevant folder, for example if your run the Embedded Jetty:</p>
-				<source>cp -R target/generated-sources/js/org/apache/openmeetings/* target/openmeetings-web-6.0.0-SNAPSHOT/WEB-INF/classes/org/apache/openmeetings/</source>
+				<source>
+<![CDATA[
+cd openmeetings-web
+# Run NPM install on each of the packages (only required once unless you change dependency):
+mvn frontend:npm@main-install frontend:npm@chat-install frontend:npm@settings-install frontend:npm@room-install frontend:npm@wb-install
+# Run NPM 
+mvn frontend:npm@main frontend:npm@chat frontend:npm@settings frontend:npm@room frontend:npm@wb
+# Minify CSS
+mvn minify:minify@theme-minify minify:minify@nettest-js
+# Copy to destination, in this case running OpenMeetings using the embedded Jetty, see above
+export CURRENT_DIR=$(pwd)
+rsync -a $CURRENT_DIR/target/generated-sources/js/ $CURRENT_DIR/target/openmeetings-web-7.0.0-SNAPSHOT/WEB-INF/classes/
+]]>
+				</source>
+				<p>You can also copy paste above into a handy shell script and just run that on demand.</p>
+				<p>This also allows you to use another editor like WebStorm or IntelliJ for editing the OpenMeetings node npm projects!</p>
 			</div>
 		</section>
 		<section name="Fix Proxy settings">


### PR DESCRIPTION
Sync website changes back to source XML files.

There would be also a way to just run it via NPM, which is probably even more fast. But I think it is easier to just use the MVN commands, as it mimics exactly the same thing the OpenMeetings build process does.
