### PR TITLE
OPENMEETINGS-2692 Update manifest to get webapp name from base URL config.

### DIFF
--- a/openmeetings-install/src/main/java/org/apache/openmeetings/installation/ImportInitvalues.java
+++ b/openmeetings-install/src/main/java/org/apache/openmeetings/installation/ImportInitvalues.java
@@ -271,7 +271,7 @@ public class ImportInitvalues {
 						+ "It makes no sense to make this(%s) 'true' while "
 						+ "%s is 'false' cause you need to send a EMail.", CONFIG_EMAIL_VERIFICATION, CONFIG_EMAIL_AT_REGISTER), VER_2_0);
 
-		addCfg(list, CONFIG_APPLICATION_BASE_URL, cfg.getBaseUrl(), Configuration.Type.STRING, "Base URL your OPenmeetings installation will be accessible at.", "3.0.2");
+		addCfg(list, CONFIG_APPLICATION_BASE_URL, cfg.getBaseUrl(), Configuration.Type.STRING, "Base URL your Openmeetings installation will be accessible at.", "3.0.2");
 
 		// ***************************************
 		// ***************************************

--- a/openmeetings-util/src/main/java/org/apache/openmeetings/util/OpenmeetingsVariables.java
+++ b/openmeetings-util/src/main/java/org/apache/openmeetings/util/OpenmeetingsVariables.java
@@ -248,6 +248,14 @@ public class OpenmeetingsVariables {
 		return baseUrl;
 	}
 
+	public static String getWebappPath() {
+		String webappPath = baseUrl;
+		if (webappPath.endsWith("/")) {
+			webappPath = webappPath.substring(0, webappPath.length() - 1);
+		}
+		return webappPath.substring(webappPath.lastIndexOf("/") + 1);
+	}
+
 	public static void setBaseUrl(String url) {
 		baseUrl = url;
 	}

--- a/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/InfoWebService.java
+++ b/openmeetings-webservice/src/main/java/org/apache/openmeetings/webservice/InfoWebService.java
@@ -20,8 +20,6 @@ package org.apache.openmeetings.webservice;
 
 import static org.apache.openmeetings.webservice.Constants.TNS;
 
-import java.util.Locale;
-
 import javax.jws.WebMethod;
 import javax.jws.WebService;
 import javax.ws.rs.GET;
@@ -49,9 +47,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  *
- * The Service contains methods to get info about the system
+ * The Service contains methods to get info about the system and manifest
  *
- * @author solomax
+ * @author solomax, sebawagner
  *
  */
 @Service("infoWebService")
@@ -108,7 +106,7 @@ public class InfoWebService {
 		manifest.put("name", OpenmeetingsVariables.getApplicationName() + " " + Version.getVersion());
 		manifest.put("short_name", OpenmeetingsVariables.getApplicationName() + " " + Version.getVersion());
 		manifest.put("description", "Openmeetings provides video conferencing, instant messaging, white board, collaborative document editing and other groupware tools.");
-		manifest.put("start_url", "/" + OpenmeetingsVariables.getApplicationName().toLowerCase(Locale.getDefault()) + "/?pwa=true");
+		manifest.put("start_url", "/" + OpenmeetingsVariables.getWebappPath() + "/?pwa=true");
 		manifest.put("scope", "/");
 		manifest.put("background_color", "#ffffff");
 		manifest.put("theme_color", "#ffffff");
@@ -125,7 +123,7 @@ public class InfoWebService {
 
 	private JSONObject generateIcon(String name, String dimension, String purpose) {
 		JSONObject icon = new JSONObject();
-		icon.put("src", "/" + OpenmeetingsVariables.getApplicationName().toLowerCase(Locale.getDefault()) + "/images/icons/" + name);
+		icon.put("src", "/" + OpenmeetingsVariables.getWebappPath() + "/images/icons/" + name);
 		icon.put("type", "image/png");
 		icon.put("sizes", dimension);
 		icon.put("purpose", purpose);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/OPENMEETINGS-2692

Get the webapp path from the base URL configuration.