### PR TITLE
OPENMEETINGS-2725 Update css for user and minimise button

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -62,7 +62,7 @@
 	padding-inline-end: 15px;
 }
 .room-block .sb-wb .sidebar .tab.user .label {
-	width: calc((var(--sidebar-width) - 50px) / 2 - 60px);
+	width: calc((var(--sidebar-width) - 50px) / 2 - 80px);
 }
 html[dir="rtl"] .room-block .sb-wb .sidebar {
 	right: 0;
@@ -725,7 +725,7 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	display: inline-block;
 	list-style: none;
 	list-style-type: none;
-	padding: 0 .5em;
+	padding: 0 .3em;
 	border-bottom-width: inherit;
 	height: 25px;
 	position: absolute;


### PR DESCRIPTION
Seems to fix the issue to have the text visible and side panel minimise button smaller so it won't overlap with tab bar buttons:
![image](https://user-images.githubusercontent.com/5152064/164949073-e68b3963-6f31-4850-8d1f-9493741795da.png)
