### PR TITLE
OPENMEETINGS-2726 Add some border styles to quick poll fixed popup

### DIFF
--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -671,7 +671,10 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	right: 40px;
 	bottom: 40px;
 	padding: 5px;
-	background-color: var(--bs-info);
+	border: 1px solid;
+    border-radius: 0.2rem;
+    background-color: white;
+    border-color: var(--bs-info);
 }
 #quick-vote .control {
 	display: inline-block;

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -672,9 +672,9 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	bottom: 40px;
 	padding: 5px;
 	border: 1px solid;
-    border-radius: 0.2rem;
-    background-color: white;
-    border-color: var(--bs-info);
+	border-radius: 0.2rem;
+	background-color: white;
+	border-color: var(--bs-info);
 }
 #quick-vote .control {
 	display: inline-block;

--- a/openmeetings-web/src/main/webapp/css/raw-room.css
+++ b/openmeetings-web/src/main/webapp/css/raw-room.css
@@ -673,7 +673,7 @@ html[dir="rtl"] .room-block .sb-wb .sidebar {
 	padding: 5px;
 	border: 1px solid;
 	border-radius: 0.2rem;
-	background-color: white;
+	background-color:var(--bs-light);
 	border-color: var(--bs-info);
 }
 #quick-vote .control {


### PR DESCRIPTION
Add some styles to quick poll popup. I think border with white background will look better for the icons:
![image](https://user-images.githubusercontent.com/5152064/164949506-db45e2a4-0194-4d32-a48a-03acb65b6828.png)
