### PR TITLE
OPENMEETINGS-2727 Add tooltips to whiteboard tab bar buttons and only  show scroll button when there is more then 1 whiteboard to scroll

### DIFF
--- a/openmeetings-web/src/main/front/wb/src/wb-area.js
+++ b/openmeetings-web/src/main/front/wb/src/wb-area.js
@@ -193,6 +193,7 @@ module.exports = class DrawWbArea extends WbAreaBase {
 				links.prop('disabled', true).addClass('disabled');
 				elems.find('button').remove();
 			}
+			__updateTabBarPreNextWhiteboardBTNs();
 			links.off()
 				.click(function(e) {
 					e.preventDefault();
@@ -220,6 +221,19 @@ module.exports = class DrawWbArea extends WbAreaBase {
 				const textSpan = _getWbTab($(this).parent().data('wb-id')).find('.wb-nav-tab-text').first();
 				textSpan.trigger('dblclick');
 			});
+		}
+		function __updateTabBarPreNextWhiteboardBTNs() {
+			if (role === Role.PRESENTER) {
+				const tabs = $('.room-block .wb-block .tabs');
+				const tabsNav = tabs.find('ul.nav-tabs li');
+				if (tabsNav.length > 1) {
+					tabs.find('.prev.om-icon').prop('disabled', false).removeClass('disabled');
+					tabs.find('.next.om-icon').prop('disabled', false).removeClass('disabled');
+				} else {
+					tabs.find('.prev.om-icon').prop('disabled', true).addClass('disabled');
+					tabs.find('.next.om-icon').prop('disabled', true).addClass('disabled');
+				}
+			}
 		}
 
 		this.init = (callback) => {
@@ -341,6 +355,7 @@ module.exports = class DrawWbArea extends WbAreaBase {
 			_getWbTab(obj.wbId).parent().remove();
 			_getWbContent(obj.wbId).remove();
 			_actionActivateWb(obj.prevWbId);
+			__updateTabBarPreNextWhiteboardBTNs();
 		};
 		this.load = (json) => {
 			if (!_inited) {

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ar.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ar.properties.xml
@@ -977,4 +977,7 @@ see https://openmeetings.apache.org/LanguageEditor.html for Details
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[كامل المقاس]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[عرض الصفحة]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_bg.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_bg.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_bn.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_bn.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ca.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ca.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Pantalla completa]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_cs.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_cs.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_da.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_da.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Fyldig]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_de.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_de.properties.xml
@@ -981,4 +981,7 @@ Bitte am OM server {3} anmelden und sie unter Admininistration -> Gruppen prüfe
 	<entry key="wizard.button.finish"><![CDATA[Ende]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Vollformat]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Seitenbreite]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_el.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_el.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_es.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_es.properties.xml
@@ -979,4 +979,7 @@ Por favor visite el {3} servidor de OM y compruébelo en Admin -> Grupos]]></ent
 	<entry key="wizard.button.finish"><![CDATA[Finalizar]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Pantalla completa]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Ancho de página]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fa.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fa.properties.xml
@@ -972,4 +972,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[پایان]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[کاملا مناسب]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[عرض صفحه]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fi.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fi.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fr.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_fr.properties.xml
@@ -980,4 +980,7 @@ dans {1} jours. Si vous souhaitez sauvegarder cet enregistrement, veuillez le tÃ
 	<entry key="wizard.button.finish"><![CDATA[Terminer]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[remplir l'espace]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Largeur de la page]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_gl.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_gl.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Pantalla completa]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_hi.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_hi.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_hu.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_hu.properties.xml
@@ -966,4 +966,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Teljes méret]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_in.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_in.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_it.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_it.properties.xml
@@ -979,4 +979,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Termina]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Schermo-Intero]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_iw.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_iw.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ja.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ja.properties.xml
@@ -978,4 +978,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[インストール]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[画面サイズに合わせる]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[ページ幅に合わせる]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ko.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ko.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ku.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ku.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_lo.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_lo.properties.xml
@@ -977,4 +977,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_nl.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_nl.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Beeldvullend]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pl.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pl.properties.xml
@@ -977,4 +977,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Zakończ]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Wypełnienie]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Szerokość strony]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pt.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pt.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pt_BR.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_pt_BR.properties.xml
@@ -978,4 +978,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Ajuste]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ru.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ru.properties.xml
@@ -978,4 +978,7 @@ see https://openmeetings.apache.org/LanguageEditor.html for Details
 	<entry key="wizard.button.finish"><![CDATA[Закончить]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[По размеру страницы]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[По ширине страницы]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_sk.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_sk.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Napasovanie]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_sv.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_sv.properties.xml
@@ -985,4 +985,7 @@ vänligen ladda ned den dessförrinnan. ]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Avsluta]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Sidbredd]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ta.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ta.properties.xml
@@ -988,4 +988,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_th.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_th.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_tk.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_tk.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_tr.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_tr.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_uk.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_uk.properties.xml
@@ -977,4 +977,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Закінчити]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ur.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_ur.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_zh_CN.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_zh_CN.properties.xml
@@ -978,4 +978,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[满屏]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_zh_TW.properties.xml
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/app/Application_zh_TW.properties.xml
@@ -986,4 +986,7 @@ Please visit {3} OM server and check them under Admin -> Groups]]></entry>
 	<entry key="wizard.button.finish"><![CDATA[Finish]]></entry>
 	<entry key="zoom.FULL_FIT"><![CDATA[Full-Fit]]></entry>
 	<entry key="zoom.PAGE_WIDTH"><![CDATA[Page Width]]></entry>
+	<entry key="wb.add.whiteboard"><![CDATA[Add new whiteboard to conference room]]></entry>
+	<entry key="wb.pre.whiteboard"><![CDATA[Scroll whiteboard tabbar right]]></entry>
+	<entry key="wb.next.whiteboard"><![CDATA[Scroll whiteboard tabbar left]]></entry>
 </properties>

--- a/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
+++ b/openmeetings-web/src/main/java/org/apache/openmeetings/web/room/wb/WbPanel.html
@@ -33,11 +33,11 @@
 	<div hidden="hidden">
 		<div id="wb-text-style-block"></div>
 		<div id="wb-tabbar-ctrls-left">
-			<div class="add clickable om-icon big"></div>
-			<div class="prev clickable om-icon big"></div>
+			<div wicket:message="title:wb.add.whiteboard" class="add clickable om-icon big"></div>
+			<div wicket:message="title:wb.pre.whiteboard" class="prev clickable om-icon big disabled"></div>
 		</div>
 		<div id="wb-tabbar-ctrls-right">
-			<div class="next clickable om-icon big"></div>
+			<div wicket:message="title:wb.next.whiteboard" class="next clickable om-icon big disabled"></div>
 		</div>
 		<ul>
 			<li id="wb-area-tab" class="nav-item">


### PR DESCRIPTION
Add tooltip to buttons:
![image](https://user-images.githubusercontent.com/5152064/165007183-11e85591-f441-4e1a-b1d7-a5b84c6134b8.png)

And scroll button get only enabled in case there is more then 1 whiteboard available
![image](https://user-images.githubusercontent.com/5152064/165007262-c346fe94-d94e-4704-822a-74ad9a746b9f.png)
