### PR TITLE
OPENMEETINGS-2743 Add option to use bytebuddy for Wicket cglib.

### DIFF
--- a/openmeetings-server/src/site/xdoc/BuildInstructions.xml
+++ b/openmeetings-server/src/site/xdoc/BuildInstructions.xml
@@ -63,10 +63,10 @@
 		<section name="Tips and Gotchas">
 			<p>Eclipse ANSI colors plugin for colors in console</p>
 			<source><![CDATA[
-MAVEN_OPTS='-Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n' mvn clean -P allModules,quick,mysql jetty:run-exploded
+MAVEN_OPTS='-Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n' mvn clean -P allModules,quick,mysql jetty:run-exploded -Dwicket.ioc.useByteBuddy=true
 
 #Quick rebuild and run
-cd ..; mvn clean install -PallModules,quick,mysql -pl openmeetings-util,openmeetings-core; cd openmeetings-web; MAVEN_OPTS='-Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n' mvn clean -P allModules,quick,mysql jetty:run-exploded
+cd ..; mvn clean install -PallModules,quick,mysql -pl openmeetings-util,openmeetings-core; cd openmeetings-web; MAVEN_OPTS='-Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n' mvn clean -P allModules,quick,mysql jetty:run-exploded -Dwicket.ioc.useByteBuddy=true
 
 			]]></source>
 			<p>In case you would like to develop Openmeetings you need to run <i>"unpacked"</i> build: </p>

--- a/openmeetings-web/pom.xml
+++ b/openmeetings-web/pom.xml
@@ -47,6 +47,10 @@
 					<groupId>mysql</groupId>
 					<artifactId>mysql-connector-java</artifactId>
 				</dependency>
+				<dependency>
+					<groupId>net.bytebuddy</groupId>
+					<artifactId>byte-buddy</artifactId>
+				</dependency>
 			</dependencies>
 		</profile>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
 		<jquery-ui-touch-punch.version>0.2.3-2</jquery-ui-touch-punch.version>
 		<apacheds-test-framework.version>2.0.0.AM26</apacheds-test-framework.version>
 		<swagger.version>2.2.1</swagger.version>
+		<bytebuddy.version>1.12.10</bytebuddy.version>
 		<!--  Exclude all generated code  -->
 		<sonar.exclusions>file:**/generated-sources/**, file:**/jquery-ui.css, file:**/cssemoticons.js, file:**/bootstrap-confirmation.js</sonar.exclusions>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -868,6 +869,16 @@
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
 				<version>${mysql.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>mysql</groupId>
+				<artifactId>mysql-connector-java</artifactId>
+				<version>${mysql.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.bytebuddy</groupId>
+				<artifactId>byte-buddy</artifactId>
+				<version>${bytebuddy.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -871,11 +871,6 @@
 				<version>${mysql.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>mysql</groupId>
-				<artifactId>mysql-connector-java</artifactId>
-				<version>${mysql.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
 				<version>${bytebuddy.version}</version>


### PR DESCRIPTION
Use **-Dwicket.ioc.useByteBuddy=true**
`mvn install -P allModules,quick,mysql jetty:run -Dwicket.configuration=DEVELOPMENT -Dwicket.ioc.useByteBuddy=true`

And include bytebuddy for mysql profile only for now. 

I'm not sure why you would not needed it you run Tomcat. Only for Jetty.
